### PR TITLE
LPS-89415 Add properties check

### DIFF
--- a/modules/apps/segments/segments-asah-rest-api/src/main/java/com/liferay/segments/asah/rest/dto/v1_0/ExperimentRun.java
+++ b/modules/apps/segments/segments-asah-rest-api/src/main/java/com/liferay/segments/asah/rest/dto/v1_0/ExperimentRun.java
@@ -45,7 +45,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 @Generated("")
 @GraphQLName("ExperimentRun")
 @JsonFilter("Liferay.Vulcan")
-@Schema(requiredProperties = {"confidenceLevel", "variants"})
+@Schema(requiredProperties = {"confidenceLevel", "experimentVariants"})
 @XmlRootElement(name = "ExperimentRun")
 public class ExperimentRun {
 
@@ -107,6 +107,7 @@ public class ExperimentRun {
 
 	@GraphQLField
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@NotNull
 	protected ExperimentVariant[] experimentVariants;
 
 	@Schema

--- a/modules/apps/segments/segments-asah-rest-impl/rest-openapi.yaml
+++ b/modules/apps/segments/segments-asah-rest-impl/rest-openapi.yaml
@@ -45,7 +45,7 @@ components:
                     type: string
             required:
                 - confidenceLevel
-                - variants
+                - experimentVariants
             type: object
         ExperimentVariant:
             properties:

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
@@ -1393,8 +1393,8 @@ public class RESTBuilder {
 
 				String tmp = null;
 
-				if ((description != null) &&
-					description.startsWith("https://www.schema.org/")) {
+				if (StringUtil.startsWith(
+						description, "https://www.schema.org/")) {
 
 					tmp = description;
 				}

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
@@ -1391,9 +1391,20 @@ public class RESTBuilder {
 
 				String description = propertySchema.getDescription();
 
-				if ((description == null) ||
-					!description.startsWith("https://www.schema.org/")) {
+				String tmp = null;
 
+				if ((description != null) &&
+					description.startsWith("https://www.schema.org/")) {
+
+					tmp = description;
+				}
+				else if (propertySchema.getItems() != null) {
+					Items items = propertySchema.getItems();
+
+					tmp = items.getReference();
+				}
+
+				if (tmp == null) {
 					continue;
 				}
 
@@ -1404,7 +1415,7 @@ public class RESTBuilder {
 				int z = s.indexOf(':', y);
 
 				String schemaVarName = freeMarkerTool.getSchemaVarName(
-					description.substring(description.lastIndexOf('/') + 1));
+					tmp.substring(tmp.lastIndexOf('/') + 1));
 
 				if (Objects.equals(propertySchema.getType(), "array")) {
 					String plural = TextFormatter.formatPlural(schemaVarName);

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/RESTBuilder.java
@@ -1548,6 +1548,30 @@ public class RESTBuilder {
 					System.out.println(sb.toString());
 				}
 			}
+
+			if (schema.getRequiredPropertySchemaNames() == null) {
+				continue;
+			}
+
+			List<String> requiredPropertySchemaNames =
+				schema.getRequiredPropertySchemaNames();
+
+			Set<String> propertySchemaNames = propertySchemas.keySet();
+
+			for (String requiredPropertySchemaName :
+					requiredPropertySchemaNames) {
+
+				if (!propertySchemaNames.contains(requiredPropertySchemaName)) {
+					StringBuilder sb = new StringBuilder();
+
+					sb.append("The required property \"");
+					sb.append(requiredPropertySchemaName);
+					sb.append("\" is not defined in ");
+					sb.append(entry1.getKey());
+
+					System.out.println(sb.toString());
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Can you have a look at this: https://github.com/liferay/liferay-portal/blob/master/modules/apps/headless/headless-form/headless-form-impl/rest-openapi.yaml#L77-L80
```
                formFieldValues:
                    description: https://www.schema.org/FormFieldValue
                    items:
                        $ref: "#/components/schemas/FormFieldValue"
```

The property `formFieldValues` has both `description:` and `$ref:`.

Before my fix, the property `formFieldValues` will be replaced with formatted(lower cased and plural version)  `FormFieldValue` that comes from `description: https://www.schema.org/FormFieldValue`

Now I added the logic that also check `$ref`.

My question is: Is there any case that FormFieldValue will be different in `description` and `$ref`?