### PR TITLE
LPS-84119 Chaining

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/ChainingCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/ChainingCheck.java
@@ -172,6 +172,8 @@ public class ChainingCheck extends BaseCheck {
 
 			_checkAllowedChaining(methodCallDetailAST);
 
+			_checkNotAllowedClassChaining(methodCallDetailAST);
+
 			List<String> chainedMethodNames = _getChainedMethodNames(
 				methodCallDetailAST);
 
@@ -284,6 +286,32 @@ public class ChainingCheck extends BaseCheck {
 				methodCallDetailAST, TokenTypes.SUPER_CTOR_CALL)) {
 
 			log(methodCallDetailAST, _MSG_AVOID_METHOD_CHAINING, methodName);
+		}
+	}
+
+	private void _checkNotAllowedClassChaining(DetailAST methodCallDetailAST) {
+		DetailAST dotDetailAST = methodCallDetailAST.findFirstToken(
+			TokenTypes.DOT);
+
+		if (dotDetailAST == null) {
+			return;
+		}
+
+		DetailAST newDetailAST = dotDetailAST.getFirstChild();
+
+		if (newDetailAST.getType() != TokenTypes.LITERAL_NEW) {
+			return;
+		}
+
+		DetailAST identDetailAST = newDetailAST.getFirstChild();
+
+		String className = identDetailAST.getText();
+
+		List<String> notAllowedClassNames = getAttributeValues(
+			_NOT_ALLOWED_CLASS_NAMES_KEY);
+
+		if (notAllowedClassNames.contains(className)) {
+			log(dotDetailAST.getParent(), _MSG_AVOID_CLASS_CHAINING, className);
 		}
 	}
 
@@ -883,6 +911,9 @@ public class ChainingCheck extends BaseCheck {
 
 	private static final String _MSG_ALLOWED_CHAINING = "chaining.allowed";
 
+	private static final String _MSG_AVOID_CLASS_CHAINING =
+		"chaining.avoid.class";
+
 	private static final String _MSG_AVOID_METHOD_CHAINING =
 		"chaining.avoid.method";
 
@@ -895,6 +926,9 @@ public class ChainingCheck extends BaseCheck {
 	private static final String _MSG_REQUIRED_CHAINING = "chaining.required";
 
 	private static final String _MSG_UNSORTED_RESPONSE = "response.unsorted";
+
+	private static final String _NOT_ALLOWED_CLASS_NAMES_KEY =
+		"notAllowedClassNames";
 
 	private static final String _REQUIRED_CHAINING_CLASS_FILE_NAMES_KEY =
 		"requiredChainingClassFileNames";

--- a/modules/util/source-formatter/src/main/resources/checkstyle.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle.xml
@@ -235,7 +235,9 @@
 			<property name="applyToTypeCast" value="true" />
 			<property name="category" value="Styling" />
 			<property name="description" value="Checks that chaining is only applied on certain types and methods" />
+			<property name="notAllowedClassNames" value="File" />
 			<message key="chaining.allowed" value="Chaining is allowed on ''{0}''" />
+			<message key="chaining.avoid.class" value="Avoid chaining on class ''{0}''" />
 			<message key="chaining.avoid.method" value="Avoid chaining on method ''{0}''" />
 			<message key="chaining.avoid.type.cast" value="Avoid chaining on Type Cast" />
 			<message key="chaining.required" value="Chaining on ''{0}'' is preferred" />


### PR DESCRIPTION
Issues:
https://github.com/liferay/liferay-portal/commit/39366ceea6dad0006230054352c72af59d4c1660
https://github.com/liferay/liferay-portal/commit/ad3024d5a946881b9ae56c80a76336a8ad26b800

```
■Start formatting on /home/alan/liferay_code/master/liferay-portal/
Loading jar:file:/home/alan/SFDebug/otherjars/portal-impl.jar!/system.properties
Loading file:/home/alan/liferay_code/master/liferay-portal/bin/system.properties
Loading file:/home/alan/liferay_code/master/liferay-portal/bin/system-ext.properties
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [file:/home/alan/liferay_code/master/liferay-portal/bin/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/home/alan/liferay_code/master/liferay-portal/lib/development/slf4j-simple.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [com.liferay.util.slf4j.LiferayLoggerFactory]
Avoid chaining on class 'ThemeDisplayBuilder': /home/alan/liferay_code/master/liferay-portal/modules/apps/depot/depot-web/src/test/java/com/liferay/depot/web/internal/display/context/DepotAdminMembershipsDisplayContextTest.java 80 (Checkstyle:ChainingCheck)
Avoid chaining on class 'ThemeDisplayBuilder': /home/alan/liferay_code/master/liferay-portal/modules/apps/depot/depot-web/src/test/java/com/liferay/depot/web/internal/display/context/DepotAdminMembershipsDisplayContextTest.java 108 (Checkstyle:ChainingCheck)
Avoid chaining on class 'ThemeDisplayBuilder': /home/alan/liferay_code/master/liferay-portal/modules/apps/depot/depot-web/src/test/java/com/liferay/depot/web/internal/display/context/DepotAdminMembershipsDisplayContextTest.java 136 (Checkstyle:ChainingCheck)
Avoid chaining on class 'ThemeDisplayBuilder': /home/alan/liferay_code/master/liferay-portal/modules/apps/depot/depot-web/src/test/java/com/liferay/depot/web/internal/display/context/DepotAdminMembershipsDisplayContextTest.java 162 (Checkstyle:ChainingCheck)
Avoid chaining on class 'ThemeDisplayBuilder': /home/alan/liferay_code/master/liferay-portal/modules/apps/depot/depot-web/src/test/java/com/liferay/depot/web/internal/display/context/DepotAdminMembershipsDisplayContextTest.java 188 (Checkstyle:ChainingCheck)
Avoid chaining on class 'ThemeDisplayBuilder': /home/alan/liferay_code/master/liferay-portal/modules/apps/depot/depot-web/src/test/java/com/liferay/depot/web/internal/display/context/DepotAdminMembershipsDisplayContextTest.java 210 (Checkstyle:ChainingCheck)
Avoid chaining on class '.': /home/alan/liferay_code/master/liferay-portal/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/DLOpenerGoogleDriveManager.java 133 (Checkstyle:ChainingCheck)
Avoid chaining on class '.': /home/alan/liferay_code/master/liferay-portal/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/DLOpenerGoogleDriveManager.java 286 (Checkstyle:ChainingCheck)
Avoid chaining on class '.': /home/alan/liferay_code/master/liferay-portal/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/DLOpenerGoogleDriveManager.java 359 (Checkstyle:ChainingCheck)
Avoid chaining on class '.': /home/alan/liferay_code/master/liferay-portal/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/background/task/UploadGoogleDriveDocumentBackgroundTaskExecutor.java 173 (Checkstyle:ChainingCheck)
Avoid chaining on class '.': /home/alan/liferay_code/master/liferay-portal/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/connected/app/GoogleDriveConnectedAppProvider.java 124 (Checkstyle:ChainingCheck)
Avoid chaining on class 'MockHttpServletRequestBuilder': /home/alan/liferay_code/master/liferay-portal/modules/apps/document-library/document-library-web/src/test/java/com/liferay/document/library/web/internal/display/context/DLEditFileEntryTypeDisplayContextTest.java 113 (Checkstyle:ChainingCheck)
Avoid chaining on class 'MockHttpServletRequestBuilder': /home/alan/liferay_code/master/liferay-portal/modules/apps/document-library/document-library-web/src/test/java/com/liferay/document/library/web/internal/display/context/DLEditFileEntryTypeDisplayContextTest.java 133 (Checkstyle:ChainingCheck)
Avoid chaining on class 'MockHttpServletRequestBuilder': /home/alan/liferay_code/master/liferay-portal/modules/apps/document-library/document-library-web/src/test/java/com/liferay/document/library/web/internal/display/context/DLEditFileEntryTypeDisplayContextTest.java 152 (Checkstyle:ChainingCheck)
Avoid chaining on class 'MockHttpServletRequestBuilder': /home/alan/liferay_code/master/liferay-portal/modules/apps/document-library/document-library-web/src/test/java/com/liferay/document/library/web/internal/display/context/DLEditFileEntryTypeDisplayContextTest.java 169 (Checkstyle:ChainingCheck)
Avoid chaining on class 'MockHttpServletRequestBuilder': /home/alan/liferay_code/master/liferay-portal/modules/apps/document-library/document-library-web/src/test/java/com/liferay/document/library/web/internal/display/context/DLEditFileEntryTypeDisplayContextTest.java 187 (Checkstyle:ChainingCheck)
Avoid chaining on class 'MockHttpServletRequestBuilder': /home/alan/liferay_code/master/liferay-portal/modules/apps/document-library/document-library-web/src/test/java/com/liferay/document/library/web/internal/display/context/DLEditFileShortcutDisplayContextTest.java 88 (Checkstyle:ChainingCheck)
Avoid chaining on class 'MockHttpServletRequestBuilder': /home/alan/liferay_code/master/liferay-portal/modules/apps/document-library/document-library-web/src/test/java/com/liferay/document/library/web/internal/display/context/DLEditFileShortcutDisplayContextTest.java 117 (Checkstyle:ChainingCheck)
Avoid chaining on class 'MockHttpServletRequestBuilder': /home/alan/liferay_code/master/liferay-portal/modules/apps/document-library/document-library-web/src/test/java/com/liferay/document/library/web/internal/display/context/DLEditFileShortcutDisplayContextTest.java 155 (Checkstyle:ChainingCheck)
Avoid chaining on class 'MockHttpServletRequestBuilder': /home/alan/liferay_code/master/liferay-portal/modules/apps/document-library/document-library-web/src/test/java/com/liferay/document/library/web/internal/display/context/DLEditFileShortcutDisplayContextTest.java 181 (Checkstyle:ChainingCheck)
Avoid chaining on class 'MockHttpServletRequestBuilder': /home/alan/liferay_code/master/liferay-portal/modules/apps/document-library/document-library-web/src/test/java/com/liferay/document/library/web/internal/display/context/DLEditFileShortcutDisplayContextTest.java 207 (Checkstyle:ChainingCheck)
Avoid chaining on class 'Object': /home/alan/liferay_code/master/liferay-portal/modules/apps/dynamic-data-mapping/dynamic-data-mapping-expression/src/main/java/com/liferay/dynamic/data/mapping/expression/internal/DDMExpressionEvaluatorVisitor.java 222 (Checkstyle:ChainingCheck)
Avoid chaining on class 'DummyFolder': /home/alan/liferay_code/master/liferay-portal/modules/apps/export-import/export-import-test-util/src/main/java/com/liferay/exportimport/test/util/internal/exportimport/staged/model/repository/DummyFolderStagedModelRepository.java 87 (Checkstyle:ChainingCheck)
Avoid chaining on class 'Dummy': /home/alan/liferay_code/master/liferay-portal/modules/apps/export-import/export-import-test-util/src/main/java/com/liferay/exportimport/test/util/internal/exportimport/staged/model/repository/DummyStagedModelRepository.java 80 (Checkstyle:ChainingCheck)
Avoid chaining on class 'FileUtil': /home/alan/liferay_code/master/liferay-portal/modules/apps/fragment/fragment-service/src/test/java/com/liferay/fragment/internal/validator/FragmentEntryValidatorImplTest.java 39 (Checkstyle:ChainingCheck)
Avoid chaining on class 'FileUtil': /home/alan/liferay_code/master/liferay-portal/modules/apps/frontend-js/frontend-js-loader-modules-extender-api/src/test/java/com/liferay/frontend/js/loader/modules/extender/npm/ModuleNameUtilTest.java 31 (Checkstyle:ChainingCheck)
Avoid chaining on class 'FileUtil': /home/alan/liferay_code/master/liferay-portal/modules/apps/layout/layout-page-template-service/src/test/java/com/liferay/layout/page/template/internal/upgrade/v3_3_0/util/EditableValuesTransformerUtilTest.java 36 (Checkstyle:ChainingCheck)
Avoid chaining on class 'FileUtil': /home/alan/liferay_code/master/liferay-portal/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/util/test/LayoutDataConverterTest.java 40 (Checkstyle:ChainingCheck)
Avoid chaining on class 'JSONFactoryUtil': /home/alan/liferay_code/master/liferay-portal/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/util/test/LayoutDataConverterTest.java 42 (Checkstyle:ChainingCheck)
Avoid chaining on class 'FileUtil': /home/alan/liferay_code/master/liferay-portal/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/validator/test/PageDefinitionValidatorTest.java 37 (Checkstyle:ChainingCheck)
Avoid chaining on class 'FileUtil': /home/alan/liferay_code/master/liferay-portal/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/validator/test/PageTemplateCollectionValidatorTest.java 36 (Checkstyle:ChainingCheck)
Avoid chaining on class 'FileUtil': /home/alan/liferay_code/master/liferay-portal/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/validator/test/PageTemplateValidatorTest.java 36 (Checkstyle:ChainingCheck)
Avoid chaining on class 'FileUtil': /home/alan/liferay_code/master/liferay-portal/modules/apps/petra/petra-json-validator/src/test/java/com/liferay/petra/json/validator/JSONValidatorTest.java 36 (Checkstyle:ChainingCheck)
Avoid chaining on class 'BoolQueryBuilder': /home/alan/liferay_code/master/liferay-portal/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/filter/MissingFilterTranslatorImpl.java 33 (Checkstyle:ChainingCheck)
Avoid chaining on class 'CircleBuilder': /home/alan/liferay_code/master/liferay-portal/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/geolocation/ElasticsearchShapeTranslator.java 57 (Checkstyle:ChainingCheck)
Avoid chaining on class 'EnvelopeBuilder': /home/alan/liferay_code/master/liferay-portal/modules/apps/portal-search-elasticsearch6/portal-search-elasticsearch6-impl/src/main/java/com/liferay/portal/search/elasticsearch6/internal/geolocation/ElasticsearchShapeTranslator.java 72 (Checkstyle:ChainingCheck)
Avoid chaining on class 'BoolQueryBuilder': /home/alan/liferay_code/master/liferay-portal/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/filter/MissingFilterTranslatorImpl.java 33 (Checkstyle:ChainingCheck)
Avoid chaining on class 'CircleBuilder': /home/alan/liferay_code/master/liferay-portal/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/geolocation/ElasticsearchShapeTranslator.java 57 (Checkstyle:ChainingCheck)
Avoid chaining on class 'EnvelopeBuilder': /home/alan/liferay_code/master/liferay-portal/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/geolocation/ElasticsearchShapeTranslator.java 72 (Checkstyle:ChainingCheck)
Avoid chaining on class 'DocumentTranslator': /home/alan/liferay_code/master/liferay-portal/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/indexing/BaseIndexingTestCase.java 155 (Checkstyle:ChainingCheck)
Avoid chaining on class 'SearchRequestImpl': /home/alan/liferay_code/master/liferay-portal/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/legacy/searcher/SearchRequestBuilderImpl.java 75 (Checkstyle:ChainingCheck)
Avoid chaining on class 'StringBundler': /home/alan/liferay_code/master/liferay-portal/modules/apps/portal-security/portal-security-ldap-api/src/test/java/com/liferay/portal/security/ldap/SafeLdapFilterTest.java 115 (Checkstyle:ChainingCheck)
Avoid chaining on class 'SafeLdapFilter': /home/alan/liferay_code/master/liferay-portal/modules/apps/portal-security/portal-security-ldap-api/src/test/java/com/liferay/portal/security/ldap/SafeLdapFilterTest.java 130 (Checkstyle:ChainingCheck)
Avoid chaining on class 'SafeLdapFilterTemplate': /home/alan/liferay_code/master/liferay-portal/modules/apps/portal-security/portal-security-ldap-api/src/test/java/com/liferay/portal/security/ldap/SafeLdapFilterTest.java 209 (Checkstyle:ChainingCheck)
Avoid chaining on class 'SafeLdapFilterTemplate': /home/alan/liferay_code/master/liferay-portal/modules/apps/portal-security/portal-security-ldap-api/src/test/java/com/liferay/portal/security/ldap/SafeLdapFilterTest.java 220 (Checkstyle:ChainingCheck)
Avoid chaining on class 'SafeLdapFilterTemplate': /home/alan/liferay_code/master/liferay-portal/modules/apps/portal-security/portal-security-ldap-api/src/test/java/com/liferay/portal/security/ldap/SafeLdapFilterTest.java 235 (Checkstyle:ChainingCheck)
Avoid chaining on class 'SafeLdapFilterTemplate': /home/alan/liferay_code/master/liferay-portal/modules/apps/portal-security/portal-security-ldap-api/src/test/java/com/liferay/portal/security/ldap/SafeLdapFilterTest.java 350 (Checkstyle:ChainingCheck)
Avoid chaining on class 'CompositeName': /home/alan/liferay_code/master/liferay-portal/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/DefaultPortalLDAP.java 1021 (Checkstyle:ChainingCheck)
Avoid chaining on class 'DeprecateBuilder': /home/alan/liferay_code/master/liferay-portal/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java 1958 (Checkstyle:ChainingCheck)
Avoid chaining on class 'FieldNameBuilder': /home/alan/liferay_code/master/liferay-portal/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java 1967 (Checkstyle:ChainingCheck)
Avoid chaining on class 'SimpleDateFormat': /home/alan/liferay_code/master/liferay-portal/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/param/converter/DateParamConverter.java 47 (Checkstyle:ChainingCheck)
Avoid chaining on class 'UpgradeWorkflow': /home/alan/liferay_code/master/liferay-portal/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_0_0/test/UpgradeWorkflowTest.java 40 (Checkstyle:ChainingCheck)
Avoid chaining on class 'HtmlUtil': /home/alan/liferay_code/master/liferay-portal/modules/apps/subscription/subscription-service/src/test/java/com/liferay/subscriptions/internal/util/SubscriptionSenderContextAttributeTest.java 33 (Checkstyle:ChainingCheck)
Avoid chaining on class 'URL': /home/alan/liferay_code/master/liferay-portal/modules/apps/users-admin/users-admin-demo-data-creator-impl/src/main/java/com/liferay/users/admin/demo/data/creator/internal/BaseUserDemoDataCreator.java 80 (Checkstyle:ChainingCheck)
Avoid chaining on class 'String': /home/alan/liferay_code/master/liferay-portal/modules/core/petra/petra-io/src/test/java/com/liferay/petra/io/unsync/UnsyncByteArrayOutputStreamTest.java 145 (Checkstyle:ChainingCheck)
Avoid chaining on class 'LinkedType1': /home/alan/liferay_code/master/liferay-portal/modules/core/petra/petra-reflect/src/test/java/com/liferay/petra/reflect/ObjectGraphUtilTest.java 116 (Checkstyle:ChainingCheck)
Avoid chaining on class 'LinkedType2': /home/alan/liferay_code/master/liferay-portal/modules/core/petra/petra-reflect/src/test/java/com/liferay/petra/reflect/ObjectGraphUtilTest.java 120 (Checkstyle:ChainingCheck)
Avoid chaining on class 'LinkedType3': /home/alan/liferay_code/master/liferay-portal/modules/core/petra/petra-reflect/src/test/java/com/liferay/petra/reflect/ObjectGraphUtilTest.java 124 (Checkstyle:ChainingCheck)
Avoid chaining on class 'LinkedType1': /home/alan/liferay_code/master/liferay-portal/modules/core/petra/petra-reflect/src/test/java/com/liferay/petra/reflect/ObjectGraphUtilTest.java 141 (Checkstyle:ChainingCheck)
Avoid chaining on class 'LinkedType2': /home/alan/liferay_code/master/liferay-portal/modules/core/petra/petra-reflect/src/test/java/com/liferay/petra/reflect/ObjectGraphUtilTest.java 145 (Checkstyle:ChainingCheck)
Avoid chaining on class 'LinkedType3': /home/alan/liferay_code/master/liferay-portal/modules/core/petra/petra-reflect/src/test/java/com/liferay/petra/reflect/ObjectGraphUtilTest.java 149 (Checkstyle:ChainingCheck)
Avoid chaining on class 'ServiceBuilder': /home/alan/liferay_code/master/liferay-portal/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/java/com/liferay/document/library/opener/onedrive/web/internal/oauth/OAuth2Manager.java 124 (Checkstyle:ChainingCheck)
Avoid chaining on class 'RankingPortletDisplayBuilder': /home/alan/liferay_code/master/liferay-portal/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/java/com/liferay/portal/search/tuning/rankings/web/internal/portlet/ResultRankingsPortlet.java 80 (Checkstyle:ChainingCheck)
Avoid chaining on class '.': /home/alan/liferay_code/master/liferay-portal/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/test/java/com/liferay/portal/search/tuning/rankings/web/internal/index/RankingTest.java 27 (Checkstyle:ChainingCheck)
Avoid chaining on class '.': /home/alan/liferay_code/master/liferay-portal/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/test/java/com/liferay/portal/search/tuning/rankings/web/internal/index/RankingToDocumentTranslatorTest.java 67 (Checkstyle:ChainingCheck)
Avoid chaining on class 'DateTime': /home/alan/liferay_code/master/liferay-portal/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileIntegrationTest.java 866 (Checkstyle:ChainingCheck)
Avoid chaining on class 'DateTime': /home/alan/liferay_code/master/liferay-portal/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileIntegrationTest.java 904 (Checkstyle:ChainingCheck)
Avoid chaining on class 'Callable': /home/alan/liferay_code/master/liferay-portal/modules/test/poshi-runner/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/BaseWebDriverImpl.java 1264 (Checkstyle:ChainingCheck)
Avoid chaining on class 'Random': /home/alan/liferay_code/master/liferay-portal/modules/util/portal-tools-sample-sql-builder/src/test/java/com/liferay/portal/tools/sample/sql/builder/io/CharPipeTest.java 778 (Checkstyle:ChainingCheck)
Avoid chaining on class 'GregorianCalendar': /home/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/social/kernel/util/SocialCounterPeriodUtil.java 249 (Checkstyle:ChainingCheck)
Avoid chaining on class 'DefaultParser': /home/alan/liferay_code/master/liferay-portal/util-java/src/com/liferay/util/HTMLParser.java 33 (Checkstyle:ChainingCheck)
finished in 358665

```