### PR TITLE
LPS-105380 Enforce name of var to match type for type 'SearchRequest' and 'SearchResponse'

### DIFF
--- a/modules/util/source-formatter/src/main/resources/checkstyle.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle.xml
@@ -563,7 +563,7 @@
 		<module name="com.liferay.source.formatter.checkstyle.checks.VariableNameCheck">
 			<property name="allowedVariableNames" value="bitMode,metadata,superClass,userName" />
 			<property name="enabled" value="false" />
-			<property name="enforceTypeNames" value=".*(In|Out)putStream,BaseUpgradeServiceModuleRelease,DetailAST,(Double|Int|Long)Stream,Enumeration,HttpServlet(Request|Response),Iterator,JSONArray,JSONObject,LiferayPortlet(Request|Response),NamedList,Object,OrderByComparator,Page,Query,QueryPos,RenderRequest,RenderResponse,ServletRequest,ServletResponse,SQLQuery,Throwable,UnicodeProperties,Unsync.*" />
+			<property name="enforceTypeNames" value=".*(In|Out)putStream,BaseUpgradeServiceModuleRelease,DetailAST,(Double|Int|Long)Stream,Enumeration,HttpServlet(Request|Response),Iterator,JSONArray,JSONObject,LiferayPortlet(Request|Response),NamedList,Object,OrderByComparator,Page,Query,QueryPos,RenderRequest,RenderResponse,Search(Request|Response),ServletRequest,ServletResponse,SQLQuery,Throwable,UnicodeProperties,Unsync.*" />
 			<message key="variable.incorrect.count" value="Rename variable ''{0}'' to ''{1}'' (and increment counts for other variables ''{0}*'')" />
 			<message key="variable.incorrect.ending" value="Name of variable with type ''{0}'' should end with ''{1}''" />
 			<message key="variable.name.incorrect.for.statement" value="Use format ''curVariableName'' for variable ''{0}''" />


### PR DESCRIPTION
Hi Hugo,

Issue: https://github.com/liferay/liferay-portal/commit/6d06c51ef0c9e0e9ea2d0c08438324aa9da81f6e