### PR TITLE
LPS-105380_VariableNameCheck_20210830_master

### DIFF
--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -271,7 +271,7 @@
         Connection,\
         DetailAST,\
         Enumeration,\
-        HttpContext,\
+        Http(Context|Session),\
         Iterator,\
         JSONArray,\
         JSONObject,\
@@ -328,7 +328,7 @@
         Connection,\
         DetailAST,\
         Enumeration,\
-        HttpContext,\
+        Http(Context|Session),\
         Iterator,\
         JSONArray,\
         JSONObject,\


### PR DESCRIPTION
Issue: https://github.com/liferay/liferay-portal/commit/3e9e148dceb20a356c22377e3a25a0822a8a5330

Violations:
```
java.lang.Exception: Found 266 formatting issues:
1: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/analytics/analytics-client-osgi/src/main/java/com/liferay/analytics/client/osgi/internal/AnalyticsClientImpl.java 113 (Checkstyle:VariableNameCheck)
2: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/archived/chat-service/src/main/java/com/liferay/chat/internal/events/SessionDestroyAction.java 37 (Checkstyle:VariableNameCheck)
3: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/archived/mail-reader-api/src/main/java/com/liferay/mail/reader/mailbox/PasswordRetriever.java 47 (Checkstyle:VariableNameCheck)
4: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/archived/mail-reader-api/src/main/java/com/liferay/mail/reader/mailbox/PasswordRetriever.java 53 (Checkstyle:VariableNameCheck)
5: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/archived/mail-reader-api/src/main/java/com/liferay/mail/reader/mailbox/PasswordRetriever.java 59 (Checkstyle:VariableNameCheck)
6: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/archived/portal-security-sso-google-api/src/main/java/com/liferay/portal/security/sso/google/GoogleAuthorization.java 29 (Checkstyle:VariableNameCheck)
7: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/archived/portal-security-sso-google-impl/src/main/java/com/liferay/portal/security/sso/google/internal/GoogleAuthorizationImpl.java 81 (Checkstyle:VariableNameCheck)
8: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/archived/portal-security-sso-google-impl/src/main/java/com/liferay/portal/security/sso/google/internal/GoogleAuthorizationImpl.java 202 (Checkstyle:VariableNameCheck)
9: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/archived/portal-security-sso-google-impl/src/main/java/com/liferay/portal/security/sso/google/internal/auto/login/GoogleAutoLogin.java 71 (Checkstyle:VariableNameCheck)
10: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/archived/portal-security-sso-google-login-authentication-web/src/main/java/com/liferay/portal/security/sso/google/login/authentication/web/internal/struts/GoogleLoginStrutsAction.java 90 (Checkstyle:VariableNameCheck)
11: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/servlet/CTDocumentServlet.java 149 (Checkstyle:VariableNameCheck)
12: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java 764 (Checkstyle:VariableNameCheck)
13: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/frontend-js/frontend-js-spa-web/src/main/java/com/liferay/frontend/js/spa/web/internal/servlet/taglib/helper/SPAHelper.java 134 (Checkstyle:VariableNameCheck)
14: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutsTreeImpl.java 306 (Checkstyle:VariableNameCheck)
15: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/login/login-authentication-facebook-connect-web/src/main/java/com/liferay/login/authentication/facebook/connect/web/internal/struts/FacebookConnectStrutsAction.java 134 (Checkstyle:VariableNameCheck)
16: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/login/login-authentication-facebook-connect-web/src/main/java/com/liferay/login/authentication/facebook/connect/web/internal/struts/FacebookConnectStrutsAction.java 218 (Checkstyle:VariableNameCheck)
17: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/login/login-authentication-facebook-connect-web/src/main/java/com/liferay/login/authentication/facebook/connect/web/internal/struts/FacebookConnectStrutsAction.java 323 (Checkstyle:VariableNameCheck)
18: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/login/login-authentication-openid-connect-web/src/main/java/com/liferay/login/authentication/openid/connect/web/internal/portlet/action/OpenIdConnectLoginRequestMVCActionCommand.java 134 (Checkstyle:VariableNameCheck)
19: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/CreateAccountMVCActionCommand.java 436 (Checkstyle:VariableNameCheck)
20: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/LoginMVCActionCommand.java 163 (Checkstyle:VariableNameCheck)
21: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/internal/events/MDRServicePreAction.java 64 (Checkstyle:VariableNameCheck)
22: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/monitoring/monitoring-web/src/main/java/com/liferay/monitoring/web/internal/portlet/action/EditSessionMVCActionCommand.java 94 (Checkstyle:VariableNameCheck)
23: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/monitoring/monitoring-web/src/main/java/com/liferay/monitoring/web/internal/portlet/action/EditSessionMVCActionCommand.java 129 (Checkstyle:VariableNameCheck)
24: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/shared/task/SearchHttpUtil.java 85 (Checkstyle:VariableNameCheck)
25: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/portal-security-audit/portal-security-audit-wiring/src/main/java/com/liferay/portal/security/audit/wiring/internal/servlet/filter/AuditFilter.java 90 (Checkstyle:VariableNameCheck)
26: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/portal-security-sso-ntlm/portal-security-sso-ntlm-impl/src/main/java/com/liferay/portal/security/sso/ntlm/internal/servlet/filter/NtlmFilter.java 222 (Checkstyle:VariableNameCheck)
27: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/portal-security-sso-ntlm/portal-security-sso-ntlm-impl/src/main/java/com/liferay/portal/security/sso/ntlm/internal/servlet/filter/NtlmFilter.java 241 (Checkstyle:VariableNameCheck)
28: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/portal-security-sso/portal-security-sso-cas-impl/src/main/java/com/liferay/portal/security/sso/cas/internal/auto/login/CASAutoLogin.java 81 (Checkstyle:VariableNameCheck)
29: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/portal-security-sso/portal-security-sso-cas-impl/src/main/java/com/liferay/portal/security/sso/cas/internal/auto/login/CASAutoLogin.java 112 (Checkstyle:VariableNameCheck)
30: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/portal-security-sso/portal-security-sso-cas-impl/src/main/java/com/liferay/portal/security/sso/cas/internal/servlet/filter/CASFilter.java 172 (Checkstyle:VariableNameCheck)
31: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-impl/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/FacebookConnectImpl.java 196 (Checkstyle:VariableNameCheck)
32: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-impl/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/auto/login/FacebookConnectAutoLogin.java 83 (Checkstyle:VariableNameCheck)
33: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/portal-security-sso/portal-security-sso-opensso-impl/src/main/java/com/liferay/portal/security/sso/opensso/internal/servlet/filter/OpenSSOFilter.java 134 (Checkstyle:VariableNameCheck)
34: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/portal-security-sso/portal-security-sso-opensso-impl/src/main/java/com/liferay/portal/security/sso/opensso/internal/servlet/filter/OpenSSOFilter.java 162 (Checkstyle:VariableNameCheck)
35: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/portal-security-sso/portal-security-sso-token-impl/src/main/java/com/liferay/portal/security/sso/token/internal/events/RedirectLogoutProcessor.java 53 (Checkstyle:VariableNameCheck)
36: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/portal/portal-compound-session-id/src/main/java/com/liferay/portal/compound/session/id/internal/CompoundSessionIdServletRequest.java 42 (Checkstyle:VariableNameCheck)
37: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/portal/portal-compound-session-id/src/main/java/com/liferay/portal/compound/session/id/internal/CompoundSessionIdServletRequest.java 52 (Checkstyle:VariableNameCheck)
38: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/i18n/test/I18nFilterTest.java 184 (Checkstyle:VariableNameCheck)
39: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/java/com/liferay/portlet/configuration/css/web/internal/display/context/PortletConfigurationCSSPortletDisplayContext.java 155 (Checkstyle:VariableNameCheck)
40: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/display/context/PortletConfigurationPermissionsDisplayContext.java 623 (Checkstyle:VariableNameCheck)
41: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/SharedSessionPortletContainerTest.java 102 (Checkstyle:VariableNameCheck)
42: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/SharedSessionPortletContainerTest.java 169 (Checkstyle:VariableNameCheck)
43: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/SharedSessionPortletContainerTest.java 236 (Checkstyle:VariableNameCheck)
44: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/SharedSessionPortletContainerTest.java 303 (Checkstyle:VariableNameCheck)
45: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test/src/testIntegration/java/com/liferay/portal/osgi/web/portlet/container/test/SharedSessionPortletContainerTest.java 367 (Checkstyle:VariableNameCheck)
46: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/EditUserMVCActionCommand.java 514 (Checkstyle:VariableNameCheck)
47: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/commerce-punchout/commerce-punchout-portal-security-auto-login/src/main/java/com/liferay/commerce/punchout/portal/security/auto/login/internal/events/PunchOutTokenLogoutAction.java 51 (Checkstyle:VariableNameCheck)
48: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/java/com/liferay/multi/factor/authentication/timebased/otp/web/internal/checker/TimeBasedOTPBrowserSetupMFAChecker.java 138 (Checkstyle:VariableNameCheck)
49: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators/src/main/java/com/liferay/portal/security/audit/event/generators/internal/events/ImpersonationAction.java 80 (Checkstyle:VariableNameCheck)
50: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/saml/saml-addon-keep-alive-web/src/main/java/com/liferay/saml/addon/keep/alive/web/internal/servlet/taglib/KeepAliveSPPortalDynamicInclude.java 176 (Checkstyle:VariableNameCheck)
51: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/saml/saml-addon-keep-alive-web/src/main/java/com/liferay/saml/addon/keep/alive/web/internal/servlet/taglib/KeepAliveSPPortalDynamicInclude.java 185 (Checkstyle:VariableNameCheck)
52: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/auto/login/WebSsoAutoLogin.java 63 (Checkstyle:VariableNameCheck)
53: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/events/SamlSpSessionDestroyAction.java 46 (Checkstyle:VariableNameCheck)
54: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/events/SamlSpSessionDestroyAction.java 80 (Checkstyle:VariableNameCheck)
55: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/SamlSpSsoFilter.java 219 (Checkstyle:VariableNameCheck)
56: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/BaseProfile.java 359 (Checkstyle:VariableNameCheck)
57: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/BaseProfile.java 366 (Checkstyle:VariableNameCheck)
58: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/BaseProfile.java 454 (Checkstyle:VariableNameCheck)
59: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileImpl.java 450 (Checkstyle:VariableNameCheck)
60: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileIntegrationTest.java 323 (Checkstyle:VariableNameCheck)
61: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileIntegrationTest.java 440 (Checkstyle:VariableNameCheck)
62: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/servlet/taglib/SamlBottomJSPDynamicInclude.java 68 (Checkstyle:VariableNameCheck)
63: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/sharepoint-rest/sharepoint-rest-repository/src/main/java/com/liferay/sharepoint/rest/repository/internal/document/library/repository/authorization/oauth2/SharepointRepositoryRequestState.java 40 (Checkstyle:VariableNameCheck)
64: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/sharepoint-rest/sharepoint-rest-repository/src/main/java/com/liferay/sharepoint/rest/repository/internal/document/library/repository/authorization/oauth2/SharepointRepositoryRequestState.java 49 (Checkstyle:VariableNameCheck)
65: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/sharepoint-rest/sharepoint-rest-repository/src/main/java/com/liferay/sharepoint/rest/repository/internal/document/library/repository/authorization/oauth2/SharepointRepositoryRequestState.java 71 (Checkstyle:VariableNameCheck)
66: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/action/LayoutAction.java 281 (Checkstyle:VariableNameCheck)
67: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/action/LoginAction.java 100 (Checkstyle:VariableNameCheck)
68: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/action/SessionClickAction.java 53 (Checkstyle:VariableNameCheck)
69: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/action/SessionClickAction.java 111 (Checkstyle:VariableNameCheck)
70: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/action/UpdateLanguageAction.java 89 (Checkstyle:VariableNameCheck)
71: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/action/UpdatePasswordAction.java 184 (Checkstyle:VariableNameCheck)
72: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/events/ChannelLoginPostAction.java 40 (Checkstyle:VariableNameCheck)
73: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/events/ChannelSessionDestroyAction.java 36 (Checkstyle:VariableNameCheck)
74: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/events/ClearRenderParametersAction.java 43 (Checkstyle:VariableNameCheck)
75: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/events/DefaultLandingPageAction.java 73 (Checkstyle:VariableNameCheck)
76: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/events/EventsProcessorUtil.java 65 (Checkstyle:VariableNameCheck)
77: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/events/GarbageCollectorAction.java 32 (Checkstyle:VariableNameCheck)
78: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/events/LogSessionIdAction.java 37 (Checkstyle:VariableNameCheck)
79: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/events/SampleServicePreAction.java 43 (Checkstyle:VariableNameCheck)
80: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/events/ServicePreAction.java 897 (Checkstyle:VariableNameCheck)
81: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/events/ServicePreAction.java 1827 (Checkstyle:VariableNameCheck)
82: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/events/ServicePreAction.java 1891 (Checkstyle:VariableNameCheck)
83: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/events/SessionCreateAction.java 29 (Checkstyle:VariableNameCheck)
84: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/events/SessionDestroyAction.java 29 (Checkstyle:VariableNameCheck)
85: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/internal/servlet/MainServlet.java 736 (Checkstyle:VariableNameCheck)
86: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/internal/servlet/MainServlet.java 1028 (Checkstyle:VariableNameCheck)
87: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/liveusers/LiveUsers.java 262 (Checkstyle:VariableNameCheck)
88: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/model/impl/LayoutImpl.java 1551 (Checkstyle:VariableNameCheck)
89: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/model/impl/LayoutRevisionImpl.java 135 (Checkstyle:VariableNameCheck)
90: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/security/auth/SessionAuthToken.java 228 (Checkstyle:VariableNameCheck)
91: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/security/auth/session/AuthenticatedSessionManagerImpl.java 131 (Checkstyle:VariableNameCheck)
92: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/security/auth/session/AuthenticatedSessionManagerImpl.java 319 (Checkstyle:VariableNameCheck)
93: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/security/auth/session/AuthenticatedSessionManagerImpl.java 362 (Checkstyle:VariableNameCheck)
94: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/security/permission/ResourceActionsImpl.java 1043 (Checkstyle:VariableNameCheck)
95: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/I18nServlet.java 379 (Checkstyle:VariableNameCheck)
96: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/SharedSessionImpl.java 29 (Checkstyle:VariableNameCheck)
97: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/SharedSessionImpl.java 31 (Checkstyle:VariableNameCheck)
98: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/SharedSessionServletRequest.java 52 (Checkstyle:VariableNameCheck)
99: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/SharedSessionServletRequest.java 75 (Checkstyle:VariableNameCheck)
100: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/SharedSessionServletRequest.java 80 (Checkstyle:VariableNameCheck)
101: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/SharedSessionWrapper.java 39 (Checkstyle:VariableNameCheck)
102: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/SharedSessionWrapper.java 57 (Checkstyle:VariableNameCheck)
103: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/SharedSessionWrapper.java 64 (Checkstyle:VariableNameCheck)
104: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/SharedSessionWrapper.java 90 (Checkstyle:VariableNameCheck)
105: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/SharedSessionWrapper.java 97 (Checkstyle:VariableNameCheck)
106: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/SharedSessionWrapper.java 104 (Checkstyle:VariableNameCheck)
107: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/SharedSessionWrapper.java 111 (Checkstyle:VariableNameCheck)
108: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/SharedSessionWrapper.java 118 (Checkstyle:VariableNameCheck)
109: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/SharedSessionWrapper.java 129 (Checkstyle:VariableNameCheck)
110: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/SharedSessionWrapper.java 156 (Checkstyle:VariableNameCheck)
111: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/SharedSessionWrapper.java 163 (Checkstyle:VariableNameCheck)
112: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/SharedSessionWrapper.java 179 (Checkstyle:VariableNameCheck)
113: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/SharedSessionWrapper.java 195 (Checkstyle:VariableNameCheck)
114: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/SharedSessionWrapper.java 202 (Checkstyle:VariableNameCheck)
115: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/SharedSessionWrapper.java 254 (Checkstyle:VariableNameCheck)
116: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/SharedSessionWrapper.java 255 (Checkstyle:VariableNameCheck)
117: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/filters/absoluteredirects/AbsoluteRedirectsFilter.java 73 (Checkstyle:VariableNameCheck)
118: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/filters/autologin/AutoLoginFilter.java 59 (Checkstyle:VariableNameCheck)
119: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/filters/autologin/AutoLoginFilter.java 187 (Checkstyle:VariableNameCheck)
120: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/filters/cache/CacheFilter.java 485 (Checkstyle:VariableNameCheck)
121: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/filters/header/HeaderFilter.java 140 (Checkstyle:VariableNameCheck)
122: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/filters/i18n/I18nFilter.java 223 (Checkstyle:VariableNameCheck)
123: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/filters/password/modified/PasswordModifiedFilter.java 67 (Checkstyle:VariableNameCheck)
124: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/filters/password/modified/PasswordModifiedFilter.java 105 (Checkstyle:VariableNameCheck)
125: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/filters/secure/BaseAuthFilter.java 104 (Checkstyle:VariableNameCheck)
126: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/filters/secure/BaseAuthFilter.java 153 (Checkstyle:VariableNameCheck)
127: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/filters/secure/BaseAuthFilter.java 347 (Checkstyle:VariableNameCheck)
128: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/filters/servletauthorizing/ServletAuthorizingFilter.java 48 (Checkstyle:VariableNameCheck)
129: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/filters/sessionid/SessionIdServletRequest.java 45 (Checkstyle:VariableNameCheck)
130: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/filters/sessionid/SessionIdServletRequest.java 54 (Checkstyle:VariableNameCheck)
131: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/filters/sessionid/SessionIdServletRequest.java 61 (Checkstyle:VariableNameCheck)
132: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/servlet/filters/sessionmaxallowed/SessionMaxAllowedFilter.java 38 (Checkstyle:VariableNameCheck)
133: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/setup/SetupWizardUtil.java 152 (Checkstyle:VariableNameCheck)
134: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/setup/SetupWizardUtil.java 199 (Checkstyle:VariableNameCheck)
135: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/setup/SetupWizardUtil.java 386 (Checkstyle:VariableNameCheck)
136: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/sharepoint/SharepointDocumentWorkspaceServlet.java 293 (Checkstyle:VariableNameCheck)
137: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/sharepoint/SharepointServlet.java 75 (Checkstyle:VariableNameCheck)
138: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/struts/PortalRequestProcessor.java 266 (Checkstyle:VariableNameCheck)
139: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/struts/PortalRequestProcessor.java 432 (Checkstyle:VariableNameCheck)
140: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/struts/PortalRequestProcessor.java 448 (Checkstyle:VariableNameCheck)
141: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/upload/LiferayInputStream.java 189 (Checkstyle:VariableNameCheck)
142: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/upload/UploadServletRequestImpl.java 87 (Checkstyle:VariableNameCheck)
143: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/util/HttpImpl.java 448 (Checkstyle:VariableNameCheck)
144: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/util/MaintenanceUtil.java 46 (Checkstyle:VariableNameCheck)
145: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/util/MaintenanceUtil.java 86 (Checkstyle:VariableNameCheck)
146: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/util/PortalImpl.java 1115 (Checkstyle:VariableNameCheck)
147: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/util/PortalImpl.java 3416 (Checkstyle:VariableNameCheck)
148: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/util/SessionLayoutClone.java 33 (Checkstyle:VariableNameCheck)
149: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/util/SessionLayoutClone.java 42 (Checkstyle:VariableNameCheck)
150: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java 1395 (Checkstyle:VariableNameCheck)
151: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/workflow/UserWorkflowHandler.java 116 (Checkstyle:VariableNameCheck)
152: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portlet/InvokerPortletUtil.java 36 (Checkstyle:VariableNameCheck)
153: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portlet/InvokerPortletUtil.java 60 (Checkstyle:VariableNameCheck)
154: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portlet/PortletPreferencesFactoryImpl.java 350 (Checkstyle:VariableNameCheck)
155: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portlet/PortletServletRequest.java 424 (Checkstyle:VariableNameCheck)
156: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portlet/PortletServletSession.java 31 (Checkstyle:VariableNameCheck)
157: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portlet/PortletSessionAttributeMap.java 38 (Checkstyle:VariableNameCheck)
158: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portlet/PortletSessionAttributeMap.java 42 (Checkstyle:VariableNameCheck)
159: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portlet/PortletSessionAttributeMap.java 190 (Checkstyle:VariableNameCheck)
160: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portlet/PublicRenderParametersPool.java 46 (Checkstyle:VariableNameCheck)
161: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portlet/PublicRenderParametersPool.java 48 (Checkstyle:VariableNameCheck)
162: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portlet/RenderParametersPool.java 132 (Checkstyle:VariableNameCheck)
163: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portlet/RenderParametersPool.java 134 (Checkstyle:VariableNameCheck)
164: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portlet/internal/PortletRequestImpl.java 535 (Checkstyle:VariableNameCheck)
165: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portlet/internal/PortletSessionImpl.java 55 (Checkstyle:VariableNameCheck)
166: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portlet/internal/PortletSessionImpl.java 216 (Checkstyle:VariableNameCheck)
167: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portlet/internal/PortletSessionImpl.java 227 (Checkstyle:VariableNameCheck)
168: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portlet/internal/PortletSessionImpl.java 229 (Checkstyle:VariableNameCheck)
169: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portlet/internal/PortletSessionImpl.java 383 (Checkstyle:VariableNameCheck)
170: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portlet/internal/PortletURLImpl.java 1198 (Checkstyle:VariableNameCheck)
171: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/test/unit/com/liferay/portlet/PortletSessionAttributeMapTest.java 434 (Checkstyle:VariableNameCheck)
172: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-impl/test/unit/com/liferay/portlet/internal/PortletSessionImplTest.java 143 (Checkstyle:VariableNameCheck)
173: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/events/InvokerSessionAction.java 36 (Checkstyle:VariableNameCheck)
174: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/events/LifecycleEvent.java 37 (Checkstyle:VariableNameCheck)
175: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/events/LifecycleEvent.java 47 (Checkstyle:VariableNameCheck)
176: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/events/LifecycleEvent.java 74 (Checkstyle:VariableNameCheck)
177: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/events/SessionAction.java 31 (Checkstyle:VariableNameCheck)
178: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/portlet/LiferayPortletSession.java 30 (Checkstyle:VariableNameCheck)
179: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/portlet/PortletPreferencesFactory.java 74 (Checkstyle:VariableNameCheck)
180: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/portlet/PortletPreferencesFactoryUtil.java 109 (Checkstyle:VariableNameCheck)
181: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/resiliency/spi/agent/AcceptorServlet.java 85 (Checkstyle:VariableNameCheck)
182: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/security/auth/session/AuthenticatedSessionManager.java 45 (Checkstyle:VariableNameCheck)
183: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/security/auth/session/AuthenticatedSessionManagerUtil.java 65 (Checkstyle:VariableNameCheck)
184: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/HttpSessionWrapper.java 28 (Checkstyle:VariableNameCheck)
185: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/HttpSessionWrapper.java 157 (Checkstyle:VariableNameCheck)
186: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalMessages.java 75 (Checkstyle:VariableNameCheck)
187: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalMessages.java 79 (Checkstyle:VariableNameCheck)
188: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalMessages.java 83 (Checkstyle:VariableNameCheck)
189: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalMessages.java 89 (Checkstyle:VariableNameCheck)
190: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalMessages.java 121 (Checkstyle:VariableNameCheck)
191: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalMessages.java 145 (Checkstyle:VariableNameCheck)
192: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalMessages.java 149 (Checkstyle:VariableNameCheck)
193: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalMessages.java 182 (Checkstyle:VariableNameCheck)
194: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalMessages.java 186 (Checkstyle:VariableNameCheck)
195: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalMessages.java 209 (Checkstyle:VariableNameCheck)
196: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalMessages.java 229 (Checkstyle:VariableNameCheck)
197: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalMessages.java 251 (Checkstyle:VariableNameCheck)
198: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalMessages.java 269 (Checkstyle:VariableNameCheck)
199: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalMessages.java 285 (Checkstyle:VariableNameCheck)
200: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalMessages.java 300 (Checkstyle:VariableNameCheck)
201: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalSessionContext.java 42 (Checkstyle:VariableNameCheck)
202: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/PortalSessionThreadLocal.java 36 (Checkstyle:VariableNameCheck)
203: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/PortletServlet.java 69 (Checkstyle:VariableNameCheck)
204: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/PortletServlet.java 109 (Checkstyle:VariableNameCheck)
205: Name of method returning type 'HttpSession' should end with 'HttpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/PortletServlet.java 125 (Checkstyle:MethodNamingCheck)
206: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/PortletServlet.java 136 (Checkstyle:VariableNameCheck)
207: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SerializableSessionAttributeListener.java 52 (Checkstyle:VariableNameCheck)
208: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SerializableSessionAttributeListener.java 63 (Checkstyle:VariableNameCheck)
209: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionErrors.java 66 (Checkstyle:VariableNameCheck)
210: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionErrors.java 70 (Checkstyle:VariableNameCheck)
211: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionErrors.java 74 (Checkstyle:VariableNameCheck)
212: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionErrors.java 88 (Checkstyle:VariableNameCheck)
213: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionErrors.java 167 (Checkstyle:VariableNameCheck)
214: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionErrors.java 201 (Checkstyle:VariableNameCheck)
215: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionErrors.java 205 (Checkstyle:VariableNameCheck)
216: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionErrors.java 215 (Checkstyle:VariableNameCheck)
217: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionErrors.java 265 (Checkstyle:VariableNameCheck)
218: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionErrors.java 269 (Checkstyle:VariableNameCheck)
219: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionErrors.java 297 (Checkstyle:VariableNameCheck)
220: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionErrors.java 323 (Checkstyle:VariableNameCheck)
221: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionErrors.java 355 (Checkstyle:VariableNameCheck)
222: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionErrors.java 379 (Checkstyle:VariableNameCheck)
223: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionErrors.java 412 (Checkstyle:VariableNameCheck)
224: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionErrors.java 449 (Checkstyle:VariableNameCheck)
225: Name of method returning type 'HttpSession' should end with 'HttpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionErrors.java 486 (Checkstyle:MethodNamingCheck)
226: Name of method returning type 'HttpSession' should end with 'HttpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionErrors.java 495 (Checkstyle:MethodNamingCheck)
227: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionMessages.java 98 (Checkstyle:VariableNameCheck)
228: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionMessages.java 102 (Checkstyle:VariableNameCheck)
229: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionMessages.java 106 (Checkstyle:VariableNameCheck)
230: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionMessages.java 120 (Checkstyle:VariableNameCheck)
231: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionMessages.java 199 (Checkstyle:VariableNameCheck)
232: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionMessages.java 233 (Checkstyle:VariableNameCheck)
233: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionMessages.java 237 (Checkstyle:VariableNameCheck)
234: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionMessages.java 247 (Checkstyle:VariableNameCheck)
235: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionMessages.java 297 (Checkstyle:VariableNameCheck)
236: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionMessages.java 301 (Checkstyle:VariableNameCheck)
237: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionMessages.java 329 (Checkstyle:VariableNameCheck)
238: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionMessages.java 355 (Checkstyle:VariableNameCheck)
239: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionMessages.java 387 (Checkstyle:VariableNameCheck)
240: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionMessages.java 411 (Checkstyle:VariableNameCheck)
241: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionMessages.java 444 (Checkstyle:VariableNameCheck)
242: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionMessages.java 481 (Checkstyle:VariableNameCheck)
243: Name of method returning type 'HttpSession' should end with 'HttpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionMessages.java 518 (Checkstyle:MethodNamingCheck)
244: Name of method returning type 'HttpSession' should end with 'HttpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SessionMessages.java 527 (Checkstyle:MethodNamingCheck)
245: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SharedSession.java 26 (Checkstyle:VariableNameCheck)
246: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/SharedSessionUtil.java 26 (Checkstyle:VariableNameCheck)
247: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/filters/compoundsessionid/CompoundSessionIdHttpSession.java 26 (Checkstyle:VariableNameCheck)
248: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/servlet/taglib/ui/BreadcrumbUtil.java 229 (Checkstyle:VariableNameCheck)
249: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/util/Portal.java 1106 (Checkstyle:VariableNameCheck)
250: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/util/PortalUtil.java 1786 (Checkstyle:VariableNameCheck)
251: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/util/ProgressTracker.java 55 (Checkstyle:VariableNameCheck)
252: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/util/ProgressTracker.java 86 (Checkstyle:VariableNameCheck)
253: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/util/ProgressTracker.java 115 (Checkstyle:VariableNameCheck)
254: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/util/SessionClicks.java 61 (Checkstyle:VariableNameCheck)
255: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/util/SessionClicks.java 67 (Checkstyle:VariableNameCheck)
256: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/util/SessionClicks.java 141 (Checkstyle:VariableNameCheck)
257: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/util/SessionClicks.java 146 (Checkstyle:VariableNameCheck)
258: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/util/SessionParamUtil.java 41 (Checkstyle:VariableNameCheck)
259: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/util/SessionParamUtil.java 109 (Checkstyle:VariableNameCheck)
260: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/util/SessionParamUtil.java 138 (Checkstyle:VariableNameCheck)
261: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/util/SessionParamUtil.java 248 (Checkstyle:VariableNameCheck)
262: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/util/SessionParamUtil.java 314 (Checkstyle:VariableNameCheck)
263: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/util/SessionParamUtil.java 379 (Checkstyle:VariableNameCheck)
264: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/util/SessionParamUtil.java 445 (Checkstyle:VariableNameCheck)
265: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/util-java/src/com/liferay/util/servlet/SessionParameters.java 50 (Checkstyle:VariableNameCheck)
266: Name of variable with type 'HttpSession' should end with 'httpSession': /Users/alan/liferay_code/master/liferay-portal/util-java/src/com/liferay/util/servlet/SessionParameters.java 92 (Checkstyle:VariableNameCheck)

```