### PR TITLE
LPS-105380 Get rid of the prints that come from poshi-core

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/PoshiSourceProcessor.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/PoshiSourceProcessor.java
@@ -14,6 +14,7 @@
 
 package com.liferay.source.formatter;
 
+import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.poshi.core.PoshiContext;
 import com.liferay.poshi.core.elements.PoshiElement;
@@ -24,7 +25,10 @@ import com.liferay.source.formatter.checks.util.SourceUtil;
 import com.liferay.source.formatter.util.DebugUtil;
 
 import java.io.File;
+import java.io.FileDescriptor;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.PrintStream;
 
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -89,9 +93,27 @@ public class PoshiSourceProcessor extends BaseSourceProcessor {
 
 		_populateFunctionAndMacroFiles();
 
+		System.out.flush();
+
+		UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
+			new UnsyncByteArrayOutputStream();
+
+		PrintStream printStream = new PrintStream(unsyncByteArrayOutputStream);
+
+		System.setOut(printStream);
+
 		PoshiElement poshiElement =
 			(PoshiElement)PoshiNodeFactory.newPoshiNodeFromFile(
 				FileUtil.getURL(file));
+
+		System.out.flush();
+
+		FileOutputStream fileOutputStream = new FileOutputStream(
+			FileDescriptor.out);
+
+		printStream = new PrintStream(fileOutputStream);
+
+		System.setOut(printStream);
 
 		PoshiScriptParserException.throwExceptions(
 			SourceUtil.getAbsolutePath(file));


### PR DESCRIPTION
_SF log issue:_

The SF log that starts with `-- listing properties` is from `poshi-core` when we use it to generate Poshi Script files.
Before https://issues.liferay.com/browse/POSHI-233 to be done, can I use this way to get rid of those prints?

```
format-source-files:
     [java] Loading file:/Users/alan/liferay_code/master/liferay-portal/portal-impl/classes/system.properties
     [java] SLF4J: Class path contains multiple SLF4J bindings.
     [java] SLF4J: Found binding in [file:/Users/alan/liferay_code/master/liferay-portal/util-slf4j/classes/org/slf4j/impl/StaticLoggerBinder.class]
     [java] SLF4J: Found binding in [jar:file:/Users/alan/liferay_code/master/liferay-portal/lib/development/slf4j-simple.jar!/org/slf4j/impl/StaticLoggerBinder.class]
     [java] SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
     [java] SLF4J: Actual binding is of type [com.liferay.util.slf4j.LiferayLoggerFactory]
     [java] -- listing properties --
     [java] accessibility.standards.json={runOnly: {type: 'tag', values: ['wcag2aa']}}
     ...
     ...APPROX 30 LINES
     ...
     [java] timeout.implicit.wait=3
     [java] 
     [echo] Updating /Users/alan/liferay_code/master/liferay-binaries-cache-2020.
```

https://github.com/liferay/liferay-portal/blob/master/modules/test/poshi/poshi-core/src/main/java/com/liferay/poshi/core/util/PropsUtil.java#L109