### PR TITLE
LPS-144015 Add unused method call check for source format

### DIFF
--- a/modules/util/source-formatter/build.gradle
+++ b/modules/util/source-formatter/build.gradle
@@ -47,6 +47,7 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.util.java", version: "2.5.0"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.apache.maven", name: "maven-plugin-api", transitive: false, version: "3.0.4"
+	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 }
 
 deployDependencies {

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/BaseAPICheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/BaseAPICheck.java
@@ -85,7 +85,7 @@ public abstract class BaseAPICheck extends BaseCheck {
 				constructorCalls.add(
 					new ConstructorCall(
 						constructorTypeName,
-						_getParameterTypeNames(literalNewDetailAST),
+						getParameterTypeNames(literalNewDetailAST),
 						literalNewDetailAST.getLineNo()));
 			}
 		}
@@ -248,7 +248,7 @@ public abstract class BaseAPICheck extends BaseCheck {
 				methodCalls.add(
 					new MethodCall(
 						methodName, variableTypeName,
-						_getParameterTypeNames(methodCallDetailAST),
+						getParameterTypeNames(methodCallDetailAST),
 						methodCallDetailAST.getLineNo()));
 			}
 		}
@@ -341,6 +341,22 @@ public abstract class BaseAPICheck extends BaseCheck {
 		}
 
 		return methodJSONObjects;
+	}
+
+	protected List<String> getParameterTypeNames(DetailAST detailAST) {
+		List<String> parameterTypeNames = new ArrayList<>();
+
+		DetailAST elistDetailAST = detailAST.findFirstToken(TokenTypes.ELIST);
+
+		List<DetailAST> exprDetailASTList = getAllChildTokens(
+			elistDetailAST, false, TokenTypes.EXPR);
+
+		for (DetailAST exprDetailAST : exprDetailASTList) {
+			parameterTypeNames.add(
+				_getParameterTypeName(exprDetailAST.getFirstChild()));
+		}
+
+		return parameterTypeNames;
 	}
 
 	protected Map<String, Set<Integer>> getTypeNamesMap(
@@ -834,22 +850,6 @@ public abstract class BaseAPICheck extends BaseCheck {
 		}
 
 		return null;
-	}
-
-	private List<String> _getParameterTypeNames(DetailAST detailAST) {
-		List<String> parameterTypeNames = new ArrayList<>();
-
-		DetailAST elistDetailAST = detailAST.findFirstToken(TokenTypes.ELIST);
-
-		List<DetailAST> exprDetailASTList = getAllChildTokens(
-			elistDetailAST, false, TokenTypes.EXPR);
-
-		for (DetailAST exprDetailAST : exprDetailASTList) {
-			parameterTypeNames.add(
-				_getParameterTypeName(exprDetailAST.getFirstChild()));
-		}
-
-		return parameterTypeNames;
 	}
 
 	private boolean _isNumeric(String typeName) {

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/UpgradeUnusedAPICheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/UpgradeUnusedAPICheck.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.source.formatter.checkstyle.checks;
+package com.liferay.source.formatter.checkstyle.check;
 
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/UpgradeUnusedAPICheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/UpgradeUnusedAPICheck.java
@@ -1,0 +1,227 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.checkstyle.checks;
+
+import com.liferay.petra.string.StringUtil;
+import com.liferay.source.formatter.util.SourceFormatterUtil;
+
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.commons.collections.ListUtils;
+
+import org.osgi.framework.Version;
+
+/**
+ * @author Simon Jiang
+ */
+public class UpgradeUnusedAPICheck extends BaseCheck {
+
+	@Override
+	public int[] getDefaultTokens() {
+		return new int[] {TokenTypes.METHOD_CALL};
+	}
+
+	@Override
+	protected void doVisitToken(DetailAST detailAST) {
+		String upgradeFromVersion = getAttributeValue(
+			SourceFormatterUtil.UPGRADE_FROM_VERSION);
+		String upgradeToVersion = getAttributeValue(
+			SourceFormatterUtil.UPGRADE_TO_VERSION);
+
+		Version upgradeFromOsgiVersion = Version.parseVersion(
+			upgradeFromVersion);
+		Version upgradeToOsgiVersion = Version.parseVersion(upgradeToVersion);
+
+		if (upgradeFromOsgiVersion.compareTo(upgradeToOsgiVersion) >= 0) {
+			return;
+		}
+
+		String targetVersion = getAttributeValue(_TARGET_VERSION);
+
+		if (!Objects.equals(targetVersion, upgradeToVersion)) {
+			return;
+		}
+
+		List<String> unusedMethodNameList = getAttributeValues(
+			_UNUSED_CLASS_METHODS_KEY);
+
+		List<UnusedClassMethod> unusedClassMethods = _getUnusedClassMethod(
+			unusedMethodNameList);
+
+		for (UnusedClassMethod unusedClassMethod : unusedClassMethods) {
+			String qualifiedPackageClassName =
+				unusedClassMethod.getQualifiedPackageClassName();
+			String methodName = unusedClassMethod.getMethodName();
+			List<String> parameterNames = unusedClassMethod.getParameterNames();
+
+			String methodCallClassOrVariableName = getClassOrVariableName(
+				detailAST);
+			String methodCallName = getMethodName(detailAST);
+
+			DetailAST variableClassDetailAST = getVariableDefinitionDetailAST(
+				detailAST, methodCallClassOrVariableName, true);
+
+			DetailAST parentDetailAST = _getParentDetailAST(detailAST);
+
+			String fullyQualifiedTypeName = null;
+
+			if (variableClassDetailAST == null) {
+				fullyQualifiedTypeName = getFullyQualifiedTypeName(
+					methodCallClassOrVariableName, detailAST, true);
+			}
+			else {
+				if (variableClassDetailAST != null) {
+					List<DetailAST> variableTypeTokens = getAllChildTokens(
+						variableClassDetailAST, true, TokenTypes.TYPE);
+
+					for (DetailAST variableTypeTokenDetailAST :
+							variableTypeTokens) {
+
+						fullyQualifiedTypeName = getVariableTypeName(
+							variableTypeTokenDetailAST,
+							methodCallClassOrVariableName, true, true, true);
+					}
+				}
+			}
+
+			List<String> methodCallParameters = new ArrayList<>();
+			List<DetailAST> allChildTokens = getAllChildTokens(
+				detailAST, true, TokenTypes.ELIST);
+
+			for (DetailAST typeArgumentDetailAST : allChildTokens) {
+				List<DetailAST> parametersAllChildTokens = getAllChildTokens(
+					typeArgumentDetailAST, true, TokenTypes.IDENT);
+
+				for (DetailAST parameterDetailAST : parametersAllChildTokens) {
+					String parameterText = parameterDetailAST.getText();
+
+					methodCallParameters.add(
+						getVariableTypeName(
+							parentDetailAST, parameterText, true, true, true));
+				}
+			}
+
+			if (Objects.equals(
+					qualifiedPackageClassName, fullyQualifiedTypeName) &&
+				Objects.equals(methodName, methodCallName) &&
+				ListUtils.isEqualList(parameterNames, methodCallParameters)) {
+
+				log(
+					detailAST, _MSG_UNUSED_METHOD, methodName,
+					fullyQualifiedTypeName, targetVersion);
+			}
+		}
+	}
+
+	private DetailAST _getParentDetailAST(DetailAST detailAST) {
+		if (detailAST != null) {
+			DetailAST parentDetailAST = detailAST.getParent();
+
+			if (parentDetailAST != null) {
+				return _getParentDetailAST(detailAST.getParent());
+			}
+		}
+
+		return detailAST;
+	}
+
+	private List<UnusedClassMethod> _getUnusedClassMethod(
+		List<String> unusedMethodNameList) {
+
+		if (Objects.nonNull(unusedMethodNameList)) {
+			List<UnusedClassMethod> unusedClassMethodList = new ArrayList<>();
+
+			for (String unusedMethodName : unusedMethodNameList) {
+				String[] unusedMethod = unusedMethodName.split("\\|");
+
+				if (unusedMethod.length < 2) {
+					continue;
+				}
+
+				String qualifiedPackageClassName = unusedMethod[0];
+
+				String methodName = unusedMethod[1];
+
+				if (unusedMethod.length == 2) {
+					unusedClassMethodList.add(
+						new UnusedClassMethod(
+							qualifiedPackageClassName, methodName));
+				}
+				else {
+					List<String> parameters = StringUtil.split(
+						unusedMethod[2], ' ');
+
+					unusedClassMethodList.add(
+						new UnusedClassMethod(
+							qualifiedPackageClassName, methodName, parameters));
+				}
+			}
+
+			return unusedClassMethodList;
+		}
+
+		return Collections.emptyList();
+	}
+
+	private static final String _MSG_UNUSED_METHOD = "method.unused";
+
+	private static final String _TARGET_VERSION = "targetVersion";
+
+	private static final String _UNUSED_CLASS_METHODS_KEY =
+		"unusedClassMethods";
+
+	private class UnusedClassMethod {
+
+		public UnusedClassMethod(
+			String qualifiedPackageClassName, String methodName) {
+
+			_qualifiedPackageClassName = qualifiedPackageClassName;
+			_methodName = methodName;
+		}
+
+		public UnusedClassMethod(
+			String qualifiedPackageClassName, String methodName,
+			List<String> parameterNames) {
+
+			_qualifiedPackageClassName = qualifiedPackageClassName;
+			_methodName = methodName;
+			_parameterNames = parameterNames;
+		}
+
+		public String getMethodName() {
+			return _methodName;
+		}
+
+		public List<String> getParameterNames() {
+			return _parameterNames;
+		}
+
+		public String getQualifiedPackageClassName() {
+			return _qualifiedPackageClassName;
+		}
+
+		private final String _methodName;
+		private List<String> _parameterNames;
+		private final String _qualifiedPackageClassName;
+
+	}
+
+}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/UpgradeUnusedAPICheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/UpgradeUnusedAPICheck.java
@@ -82,31 +82,10 @@ public class UpgradeUnusedAPICheck extends BaseCheck {
 				detailAST);
 			String methodCallName = getMethodName(detailAST);
 
-			DetailAST variableClassDetailAST = getVariableDefinitionDetailAST(
-				detailAST, methodCallClassOrVariableName, true);
-
 			DetailAST parentDetailAST = _getParentDetailAST(detailAST);
 
-			String fullyQualifiedTypeName = null;
-
-			if (variableClassDetailAST == null) {
-				fullyQualifiedTypeName = getFullyQualifiedTypeName(
-					methodCallClassOrVariableName, detailAST, true);
-			}
-			else {
-				if (variableClassDetailAST != null) {
-					List<DetailAST> variableTypeTokens = getAllChildTokens(
-						variableClassDetailAST, true, TokenTypes.TYPE);
-
-					for (DetailAST variableTypeTokenDetailAST :
-							variableTypeTokens) {
-
-						fullyQualifiedTypeName = getVariableTypeName(
-							variableTypeTokenDetailAST,
-							methodCallClassOrVariableName, true, true, true);
-					}
-				}
-			}
+			String fullyQualifiedTypeName = getVariableTypeName(
+				detailAST, methodCallClassOrVariableName, true, true, true);
 
 			List<String> methodCallParameters = new ArrayList<>();
 			List<DetailAST> allChildTokens = getAllChildTokens(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/UpgradeUnusedAPICheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/UpgradeUnusedAPICheck.java
@@ -14,15 +14,22 @@
 
 package com.liferay.source.formatter.checkstyle.checks;
 
-import com.liferay.petra.string.StringUtil;
+import com.beust.jcommander.internal.Lists;
+
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Tuple;
+import com.liferay.source.formatter.util.SourceFormatterUpgradeUtil;
 import com.liferay.source.formatter.util.SourceFormatterUtil;
 
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import org.osgi.framework.Version;
 
@@ -57,19 +64,18 @@ public class UpgradeUnusedAPICheck extends BaseAPICheck {
 			return;
 		}
 
-		String targetVersion = getAttributeValue(_TARGET_VERSION);
-
-		if (targetVersion.equals(upgradeToVersion)) {
-			return;
-		}
-
-		List<String> unusedMethodNameList = getAttributeValues(
-			_UNUSED_CLASS_METHODS_KEY);
-
-		List<UnusedClassMethod> unusedClassMethods = _getUnusedClassMethod(
-			unusedMethodNameList);
+		List<UnusedClassMethod> unusedClassMethods =
+			_getUpgradUnusedMethodNamesMap();
 
 		for (UnusedClassMethod unusedClassMethod : unusedClassMethods) {
+			String targetVersion = unusedClassMethod.getVersion();
+
+			Version targetOsgiVersion = Version.parseVersion(targetVersion);
+
+			if (upgradeToOsgiVersion.compareTo(targetOsgiVersion) < 0) {
+				continue;
+			}
+
 			String qualifiedPackageClassName =
 				unusedClassMethod.getQualifiedPackageClassName();
 			String methodName = unusedClassMethod.getMethodName();
@@ -97,64 +103,91 @@ public class UpgradeUnusedAPICheck extends BaseAPICheck {
 		}
 	}
 
-	private List<UnusedClassMethod> _getUnusedClassMethod(
-		List<String> unusedMethodNameList) {
-
-		if (unusedMethodNameList.isEmpty()) {
-			return Collections.emptyList();
+	private synchronized Tuple _getUpgradeUnusedMethodNamesTuple() {
+		if (_upgradUnusedMethodNamesTuple != null) {
+			return _upgradUnusedMethodNamesTuple;
 		}
 
-		List<UnusedClassMethod> unusedClassMethodList = new ArrayList<>();
+		_upgradUnusedMethodNamesTuple =
+			SourceFormatterUpgradeUtil.getTypeNamesTuple(
+				_UPGRADE_UNUSED_METHOD_NAME, _UPGRADE_UNUSED_METHOD_CATEGORY);
 
-		for (String unusedMethodName : unusedMethodNameList) {
-			String[] unusedMethod = unusedMethodName.split("\\|");
+		return _upgradUnusedMethodNamesTuple;
+	}
 
-			if (unusedMethod.length < 2) {
-				continue;
-			}
+	private synchronized List<UnusedClassMethod>
+		_getUpgradUnusedMethodNamesMap() {
 
-			String qualifiedPackageClassName = unusedMethod[0];
+		if (_upgradUnusedMethodNames != null) {
+			return _upgradUnusedMethodNames;
+		}
 
-			String methodName = unusedMethod[1];
+		Tuple upgradUnusedMethodNamesTuple =
+			_getUpgradeUnusedMethodNamesTuple();
 
-			if (unusedMethod.length == 2) {
-				unusedClassMethodList.add(
+		JSONObject jsonObject =
+			(JSONObject)upgradUnusedMethodNamesTuple.getObject(0);
+
+		JSONArray jsonArray = (JSONArray)jsonObject.get(
+			_UPGRADE_UNUSED_METHOD_CATEGORY);
+
+		_upgradUnusedMethodNames = new ArrayList<>();
+
+		for (Object object : JSONUtil.toObjectList(jsonArray)) {
+			jsonObject = (JSONObject)object;
+
+			String parameterNamesString = jsonObject.getString(
+				"parameterNames");
+
+			if (Objects.isNull(parameterNamesString)) {
+				_upgradUnusedMethodNames.add(
 					new UnusedClassMethod(
-						qualifiedPackageClassName, methodName));
+						jsonObject.getString("version"),
+						jsonObject.getString("className"),
+						jsonObject.getString("methodName")));
 			}
 			else {
-				List<String> parameters = StringUtil.split(
-					unusedMethod[2], ' ');
+				List<String> parameters = Lists.newArrayList(
+					StringUtil.split(parameterNamesString, ' '));
 
-				unusedClassMethodList.add(
+				_upgradUnusedMethodNames.add(
 					new UnusedClassMethod(
-						qualifiedPackageClassName, methodName, parameters));
+						jsonObject.getString("version"),
+						jsonObject.getString("className"),
+						jsonObject.getString("methodName"), parameters));
 			}
 		}
 
-		return unusedClassMethodList;
+		return _upgradUnusedMethodNames;
 	}
 
 	private static final String _MSG_UNUSED_METHOD = "method.unused";
 
-	private static final String _TARGET_VERSION = "targetVersion";
+	private static final String _UPGRADE_UNUSED_METHOD_CATEGORY =
+		"upgradUnusedMethodNames";
 
-	private static final String _UNUSED_CLASS_METHODS_KEY =
-		"unusedClassMethods";
+	private static final String _UPGRADE_UNUSED_METHOD_NAME =
+		"upgrade-unused-method-names.json";
+
+	private List<UnusedClassMethod> _upgradUnusedMethodNames;
+	private Tuple _upgradUnusedMethodNamesTuple;
 
 	private class UnusedClassMethod {
 
 		public UnusedClassMethod(
-			String qualifiedPackageClassName, String methodName) {
+			String version, String qualifiedPackageClassName,
+			String methodName) {
 
+			_version = version;
 			_qualifiedPackageClassName = qualifiedPackageClassName;
 			_methodName = methodName;
 		}
 
 		public UnusedClassMethod(
-			String qualifiedPackageClassName, String methodName,
+			String version, String qualifiedPackageClassName, String methodName,
 			List<String> parameterNames) {
 
+			_version = version;
 			_qualifiedPackageClassName = qualifiedPackageClassName;
 			_methodName = methodName;
 			_parameterNames = parameterNames;
@@ -172,9 +205,14 @@ public class UpgradeUnusedAPICheck extends BaseAPICheck {
 			return _qualifiedPackageClassName;
 		}
 
+		public String getVersion() {
+			return _version;
+		}
+
 		private final String _methodName;
 		private List<String> _parameterNames;
 		private final String _qualifiedPackageClassName;
+		private final String _version;
 
 	}
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/UpgradeUnusedAPICheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/UpgradeUnusedAPICheck.java
@@ -23,9 +23,6 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
-
-import org.apache.commons.collections.ListUtils;
 
 import org.osgi.framework.Version;
 
@@ -62,7 +59,7 @@ public class UpgradeUnusedAPICheck extends BaseAPICheck {
 
 		String targetVersion = getAttributeValue(_TARGET_VERSION);
 
-		if (!Objects.equals(targetVersion, upgradeToVersion)) {
+		if (targetVersion.equals(upgradeToVersion)) {
 			return;
 		}
 
@@ -88,10 +85,10 @@ public class UpgradeUnusedAPICheck extends BaseAPICheck {
 			List<String> methodCallParameters = getParameterTypeNames(
 				detailAST);
 
-			if (Objects.equals(
-					qualifiedPackageClassName, fullyQualifiedTypeName) &&
-				Objects.equals(methodName, methodCallName) &&
-				ListUtils.isEqualList(parameterNames, methodCallParameters)) {
+			if (qualifiedPackageClassName.equals(fullyQualifiedTypeName) &&
+				methodName.equals(methodCallName) &&
+				(parameterNames.size() == methodCallParameters.size()) &&
+				parameterNames.containsAll(methodCallParameters)) {
 
 				log(
 					detailAST, _MSG_UNUSED_METHOD, methodName,
@@ -103,7 +100,7 @@ public class UpgradeUnusedAPICheck extends BaseAPICheck {
 	private List<UnusedClassMethod> _getUnusedClassMethod(
 		List<String> unusedMethodNameList) {
 
-		if (Objects.nonNull(unusedMethodNameList)) {
+		if (!unusedMethodNameList.isEmpty()) {
 			List<UnusedClassMethod> unusedClassMethodList = new ArrayList<>();
 
 			for (String unusedMethodName : unusedMethodNameList) {

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/UpgradeUnusedAPICheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/UpgradeUnusedAPICheck.java
@@ -32,7 +32,7 @@ import org.osgi.framework.Version;
 /**
  * @author Simon Jiang
  */
-public class UpgradeUnusedAPICheck extends BaseCheck {
+public class UpgradeUnusedAPICheck extends BaseAPICheck {
 
 	@Override
 	public int[] getDefaultTokens() {
@@ -82,27 +82,11 @@ public class UpgradeUnusedAPICheck extends BaseCheck {
 				detailAST);
 			String methodCallName = getMethodName(detailAST);
 
-			DetailAST parentDetailAST = _getParentDetailAST(detailAST);
-
 			String fullyQualifiedTypeName = getVariableTypeName(
 				detailAST, methodCallClassOrVariableName, true, true, true);
 
-			List<String> methodCallParameters = new ArrayList<>();
-			List<DetailAST> allChildTokens = getAllChildTokens(
-				detailAST, true, TokenTypes.ELIST);
-
-			for (DetailAST typeArgumentDetailAST : allChildTokens) {
-				List<DetailAST> parametersAllChildTokens = getAllChildTokens(
-					typeArgumentDetailAST, true, TokenTypes.IDENT);
-
-				for (DetailAST parameterDetailAST : parametersAllChildTokens) {
-					String parameterText = parameterDetailAST.getText();
-
-					methodCallParameters.add(
-						getVariableTypeName(
-							parentDetailAST, parameterText, true, true, true));
-				}
-			}
+			List<String> methodCallParameters = getParameterTypeNames(
+				detailAST);
 
 			if (Objects.equals(
 					qualifiedPackageClassName, fullyQualifiedTypeName) &&
@@ -114,18 +98,6 @@ public class UpgradeUnusedAPICheck extends BaseCheck {
 					fullyQualifiedTypeName, targetVersion);
 			}
 		}
-	}
-
-	private DetailAST _getParentDetailAST(DetailAST detailAST) {
-		if (detailAST != null) {
-			DetailAST parentDetailAST = detailAST.getParent();
-
-			if (parentDetailAST != null) {
-				return _getParentDetailAST(detailAST.getParent());
-			}
-		}
-
-		return detailAST;
 	}
 
 	private List<UnusedClassMethod> _getUnusedClassMethod(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/UpgradeUnusedAPICheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/UpgradeUnusedAPICheck.java
@@ -27,6 +27,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -177,9 +178,9 @@ public class UpgradeUnusedAPICheck extends BaseAPICheck {
 			String version, String qualifiedPackageClassName,
 			String methodName) {
 
-			_version = version;
-			_qualifiedPackageClassName = qualifiedPackageClassName;
-			_methodName = methodName;
+			this(
+				version, qualifiedPackageClassName, methodName,
+				Collections.emptyList());
 		}
 
 		public UnusedClassMethod(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/UpgradeUnusedAPICheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/UpgradeUnusedAPICheck.java
@@ -100,39 +100,39 @@ public class UpgradeUnusedAPICheck extends BaseAPICheck {
 	private List<UnusedClassMethod> _getUnusedClassMethod(
 		List<String> unusedMethodNameList) {
 
-		if (!unusedMethodNameList.isEmpty()) {
-			List<UnusedClassMethod> unusedClassMethodList = new ArrayList<>();
-
-			for (String unusedMethodName : unusedMethodNameList) {
-				String[] unusedMethod = unusedMethodName.split("\\|");
-
-				if (unusedMethod.length < 2) {
-					continue;
-				}
-
-				String qualifiedPackageClassName = unusedMethod[0];
-
-				String methodName = unusedMethod[1];
-
-				if (unusedMethod.length == 2) {
-					unusedClassMethodList.add(
-						new UnusedClassMethod(
-							qualifiedPackageClassName, methodName));
-				}
-				else {
-					List<String> parameters = StringUtil.split(
-						unusedMethod[2], ' ');
-
-					unusedClassMethodList.add(
-						new UnusedClassMethod(
-							qualifiedPackageClassName, methodName, parameters));
-				}
-			}
-
-			return unusedClassMethodList;
+		if (unusedMethodNameList.isEmpty()) {
+			return Collections.emptyList();
 		}
 
-		return Collections.emptyList();
+		List<UnusedClassMethod> unusedClassMethodList = new ArrayList<>();
+
+		for (String unusedMethodName : unusedMethodNameList) {
+			String[] unusedMethod = unusedMethodName.split("\\|");
+
+			if (unusedMethod.length < 2) {
+				continue;
+			}
+
+			String qualifiedPackageClassName = unusedMethod[0];
+
+			String methodName = unusedMethod[1];
+
+			if (unusedMethod.length == 2) {
+				unusedClassMethodList.add(
+					new UnusedClassMethod(
+						qualifiedPackageClassName, methodName));
+			}
+			else {
+				List<String> parameters = StringUtil.split(
+					unusedMethod[2], ' ');
+
+				unusedClassMethodList.add(
+					new UnusedClassMethod(
+						qualifiedPackageClassName, methodName, parameters));
+			}
+		}
+
+		return unusedClassMethodList;
 	}
 
 	private static final String _MSG_UNUSED_METHOD = "method.unused";

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/UpgradeUnusedAPICheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/UpgradeUnusedAPICheck.java
@@ -14,8 +14,6 @@
 
 package com.liferay.source.formatter.checkstyle.checks;
 
-import com.beust.jcommander.internal.Lists;
-
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -28,6 +26,7 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
@@ -147,7 +146,7 @@ public class UpgradeUnusedAPICheck extends BaseAPICheck {
 						jsonObject.getString("methodName")));
 			}
 			else {
-				List<String> parameters = Lists.newArrayList(
+				List<String> parameters = Arrays.asList(
 					StringUtil.split(parameterNamesString, ' '));
 
 				_upgradUnusedMethodNames.add(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/UpgradeUnusedAPICheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/UpgradeUnusedAPICheck.java
@@ -64,10 +64,9 @@ public class UpgradeUnusedAPICheck extends BaseAPICheck {
 			return;
 		}
 
-		List<UnusedClassMethod> unusedClassMethods =
-			_getUpgradeUnusedMethodNamesMap();
+		for (UnusedClassMethod unusedClassMethod :
+				_getUpgradeUnusedMethodNamesMap()) {
 
-		for (UnusedClassMethod unusedClassMethod : unusedClassMethods) {
 			String targetVersion = unusedClassMethod.getVersion();
 
 			Version targetOsgiVersion = Version.parseVersion(targetVersion);

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/UpgradeUnusedAPICheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/UpgradeUnusedAPICheck.java
@@ -64,7 +64,7 @@ public class UpgradeUnusedAPICheck extends BaseAPICheck {
 		}
 
 		List<UnusedClassMethod> unusedClassMethods =
-			_getUpgradUnusedMethodNamesMap();
+			_getUpgradeUnusedMethodNamesMap();
 
 		for (UnusedClassMethod unusedClassMethod : unusedClassMethods) {
 			String targetVersion = unusedClassMethod.getVersion();
@@ -102,6 +102,52 @@ public class UpgradeUnusedAPICheck extends BaseAPICheck {
 		}
 	}
 
+	private synchronized List<UnusedClassMethod>
+		_getUpgradeUnusedMethodNamesMap() {
+
+		if (_upgradeUnusedMethodNames != null) {
+			return _upgradeUnusedMethodNames;
+		}
+
+		Tuple upgradeUnusedMethodNamesTuple =
+			_getUpgradeUnusedMethodNamesTuple();
+
+		JSONObject jsonObject =
+			(JSONObject)upgradeUnusedMethodNamesTuple.getObject(0);
+
+		JSONArray jsonArray = (JSONArray)jsonObject.get(
+			_UPGRADE_UNUSED_METHOD_CATEGORY);
+
+		_upgradeUnusedMethodNames = new ArrayList<>();
+
+		for (Object object : JSONUtil.toObjectList(jsonArray)) {
+			jsonObject = (JSONObject)object;
+
+			String parameterNamesString = jsonObject.getString(
+				"parameterNames");
+
+			if (Objects.isNull(parameterNamesString)) {
+				_upgradeUnusedMethodNames.add(
+					new UnusedClassMethod(
+						jsonObject.getString("version"),
+						jsonObject.getString("className"),
+						jsonObject.getString("methodName")));
+			}
+			else {
+				List<String> parameters = Arrays.asList(
+					StringUtil.split(parameterNamesString, ' '));
+
+				_upgradeUnusedMethodNames.add(
+					new UnusedClassMethod(
+						jsonObject.getString("version"),
+						jsonObject.getString("className"),
+						jsonObject.getString("methodName"), parameters));
+			}
+		}
+
+		return _upgradeUnusedMethodNames;
+	}
+
 	private synchronized Tuple _getUpgradeUnusedMethodNamesTuple() {
 		if (_upgradUnusedMethodNamesTuple != null) {
 			return _upgradUnusedMethodNamesTuple;
@@ -114,52 +160,6 @@ public class UpgradeUnusedAPICheck extends BaseAPICheck {
 		return _upgradUnusedMethodNamesTuple;
 	}
 
-	private synchronized List<UnusedClassMethod>
-		_getUpgradUnusedMethodNamesMap() {
-
-		if (_upgradUnusedMethodNames != null) {
-			return _upgradUnusedMethodNames;
-		}
-
-		Tuple upgradUnusedMethodNamesTuple =
-			_getUpgradeUnusedMethodNamesTuple();
-
-		JSONObject jsonObject =
-			(JSONObject)upgradUnusedMethodNamesTuple.getObject(0);
-
-		JSONArray jsonArray = (JSONArray)jsonObject.get(
-			_UPGRADE_UNUSED_METHOD_CATEGORY);
-
-		_upgradUnusedMethodNames = new ArrayList<>();
-
-		for (Object object : JSONUtil.toObjectList(jsonArray)) {
-			jsonObject = (JSONObject)object;
-
-			String parameterNamesString = jsonObject.getString(
-				"parameterNames");
-
-			if (Objects.isNull(parameterNamesString)) {
-				_upgradUnusedMethodNames.add(
-					new UnusedClassMethod(
-						jsonObject.getString("version"),
-						jsonObject.getString("className"),
-						jsonObject.getString("methodName")));
-			}
-			else {
-				List<String> parameters = Arrays.asList(
-					StringUtil.split(parameterNamesString, ' '));
-
-				_upgradUnusedMethodNames.add(
-					new UnusedClassMethod(
-						jsonObject.getString("version"),
-						jsonObject.getString("className"),
-						jsonObject.getString("methodName"), parameters));
-			}
-		}
-
-		return _upgradUnusedMethodNames;
-	}
-
 	private static final String _MSG_UNUSED_METHOD = "method.unused";
 
 	private static final String _UPGRADE_UNUSED_METHOD_CATEGORY =
@@ -168,7 +168,7 @@ public class UpgradeUnusedAPICheck extends BaseAPICheck {
 	private static final String _UPGRADE_UNUSED_METHOD_NAME =
 		"upgrade-unused-method-names.json";
 
-	private List<UnusedClassMethod> _upgradUnusedMethodNames;
+	private List<UnusedClassMethod> _upgradeUnusedMethodNames;
 	private Tuple _upgradUnusedMethodNamesTuple;
 
 	private class UnusedClassMethod {

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/UpgradeUnusedAPICheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/UpgradeUnusedAPICheck.java
@@ -163,7 +163,7 @@ public class UpgradeUnusedAPICheck extends BaseAPICheck {
 	private static final String _MSG_UNUSED_METHOD = "method.unused";
 
 	private static final String _UPGRADE_UNUSED_METHOD_CATEGORY =
-		"upgradUnusedMethodNames";
+		"upgradeUnusedMethodNames";
 
 	private static final String _UPGRADE_UNUSED_METHOD_NAME =
 		"upgrade-unused-method-names.json";

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/UpgradeUnusedAPICheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/checks/UpgradeUnusedAPICheck.java
@@ -41,6 +41,12 @@ public class UpgradeUnusedAPICheck extends BaseCheck {
 
 	@Override
 	protected void doVisitToken(DetailAST detailAST) {
+		DetailAST dotDetailAST = detailAST.findFirstToken(TokenTypes.DOT);
+
+		if (dotDetailAST == null) {
+			return;
+		}
+
 		String upgradeFromVersion = getAttributeValue(
 			SourceFormatterUtil.UPGRADE_FROM_VERSION);
 		String upgradeToVersion = getAttributeValue(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUpgradeUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUpgradeUtil.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.util;
+
+import com.liferay.portal.json.JSONArrayImpl;
+import com.liferay.portal.json.JSONObjectImpl;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Tuple;
+import com.liferay.portal.kernel.util.Validator;
+
+/**
+ * @author Simon Jiang
+ */
+public class SourceFormatterUpgradeUtil {
+
+	public static Tuple getTypeNamesTuple(String fileName, String category) {
+		JSONObject jsonObject = null;
+
+		try {
+			ClassLoader classLoader =
+				SourceFormatterUpgradeUtil.class.getClassLoader();
+
+			String content = StringUtil.read(
+				classLoader.getResourceAsStream("dependencies/" + fileName));
+
+			if (Validator.isNotNull(content)) {
+				jsonObject = new JSONObjectImpl(content);
+			}
+		}
+		catch (Exception exception) {
+		}
+
+		if (jsonObject == null) {
+			jsonObject = new JSONObjectImpl();
+
+			jsonObject.put(category, new JSONArrayImpl());
+		}
+
+		return new Tuple(jsonObject);
+	}
+
+}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUpgradeUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUpgradeUtil.java
@@ -17,6 +17,8 @@ package com.liferay.source.formatter.util;
 import com.liferay.portal.json.JSONArrayImpl;
 import com.liferay.portal.json.JSONObjectImpl;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Tuple;
 import com.liferay.portal.kernel.util.Validator;
@@ -41,6 +43,9 @@ public class SourceFormatterUpgradeUtil {
 			}
 		}
 		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception, exception);
+			}
 		}
 
 		if (jsonObject == null) {
@@ -51,5 +56,8 @@ public class SourceFormatterUpgradeUtil {
 
 		return new Tuple(jsonObject);
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SourceFormatterUpgradeUtil.class);
 
 }

--- a/modules/util/source-formatter/src/main/resources/checkstyle-jsp.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle-jsp.xml
@@ -402,8 +402,6 @@
 		<module name="com.liferay.source.formatter.checkstyle.check.UpgradeUnusedAPICheck">
 			<property name="category" value="Upgrade" />
 			<property name="description" value="Finds calls to unused class and methods after an upgrade" />
-			<property name="targetVersion" value="7.0" />
-			<property name="unusedClassMethods" value="com.liferay.portlet.asset.model.AssetRenderer|getPreviewPath|javax.portlet.PortletRequest javax.portlet.PortletResponse" />
 			<message key="method.unused" value="Method ''{0}'' no longer used in class ''{1}'' for version {2}" />
 		</module>
 		<module name="com.liferay.source.formatter.checkstyle.check.ValidatorIsNullCheck">

--- a/modules/util/source-formatter/src/main/resources/checkstyle-jsp.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle-jsp.xml
@@ -399,6 +399,13 @@
 			<property name="description" value="Finds unnecessary Type Casting." />
 			<message key="type.cast.unnecessary" value="No need to apply Type Cast to method ''{0}''" />
 		</module>
+		<module name="com.liferay.source.formatter.checkstyle.check.UpgradeUnusedAPICheck">
+			<property name="category" value="Upgrade" />
+			<property name="description" value="Finds calls to unused class and methods after an upgrade" />
+			<property name="targetVersion" value="7.0" />
+			<property name="unusedClassMethods" value="com.liferay.portlet.asset.model.AssetRenderer|getPreviewPath|javax.portlet.PortletRequest javax.portlet.PortletResponse" />
+			<message key="method.unused" value="Method ''{0}'' no longer used in class ''{1}'' for version {2}" />
+		</module>
 		<module name="com.liferay.source.formatter.checkstyle.check.ValidatorIsNullCheck">
 			<property name="category" value="Bug Prevention" />
 			<property name="description" value="Ensures that only variable of type `Long`, `Serializable` or `String` is passed to method `com.liferay.portal.kernel.util.Validator.isNull`." />

--- a/modules/util/source-formatter/src/main/resources/checkstyle-jsp.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle-jsp.xml
@@ -401,7 +401,7 @@
 		</module>
 		<module name="com.liferay.source.formatter.checkstyle.check.UpgradeUnusedAPICheck">
 			<property name="category" value="Upgrade" />
-			<property name="description" value="Finds calls to unused class and methods after an upgrade" />
+			<property name="description" value="Finds cases where calls are unused after an upgrade." />
 			<message key="method.unused" value="Method ''{0}'' no longer used in class ''{1}'' for version {2}" />
 		</module>
 		<module name="com.liferay.source.formatter.checkstyle.check.ValidatorIsNullCheck">

--- a/modules/util/source-formatter/src/main/resources/checkstyle.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle.xml
@@ -816,7 +816,7 @@
 		</module>
 		<module name="com.liferay.source.formatter.checkstyle.check.UpgradeUnusedAPICheck">
 			<property name="category" value="Upgrade" />
-			<property name="description" value="Finds calls to unused class and methods after an upgrade" />
+			<property name="description" value="Finds cases where calls are unused after an upgrade." />
 			<message key="method.unused" value="Method ''{0}'' no longer used in class ''{1}'' for version {2}" />
 		</module>
 		<module name="com.liferay.source.formatter.checkstyle.check.ValidatorIsNullCheck">

--- a/modules/util/source-formatter/src/main/resources/checkstyle.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle.xml
@@ -814,6 +814,13 @@
 			<message key="method.not.found" value="Method ''{0}'' no longer exists, or the signature has changed, in class ''{1}'' for version ''{2}''" />
 			<message key="variable.not.found" value="Variable ''{0}'' no longer exists in class ''{1}'' for version ''{2}''" />
 		</module>
+		<module name="com.liferay.source.formatter.checkstyle.check.UpgradeUnusedAPICheck">
+			<property name="category" value="Upgrade" />
+			<property name="description" value="Finds calls to unused class and methods after an upgrade" />
+			<property name="targetVersion" value="7.0" />
+			<property name="unusedClassMethods" value="com.liferay.portlet.asset.model.AssetRenderer|getPreviewPath|javax.portlet.PortletRequest javax.portlet.PortletResponse" />
+			<message key="method.unused" value="Method ''{0}'' no longer used in class ''{1}'' for version {2}" />
+		</module>
 		<module name="com.liferay.source.formatter.checkstyle.check.ValidatorIsNullCheck">
 			<property name="category" value="Bug Prevention" />
 			<property name="description" value="Ensures that only variable of type `Long`, `Serializable` or `String` is passed to method `com.liferay.portal.kernel.util.Validator.isNull`." />

--- a/modules/util/source-formatter/src/main/resources/checkstyle.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle.xml
@@ -817,8 +817,6 @@
 		<module name="com.liferay.source.formatter.checkstyle.check.UpgradeUnusedAPICheck">
 			<property name="category" value="Upgrade" />
 			<property name="description" value="Finds calls to unused class and methods after an upgrade" />
-			<property name="targetVersion" value="7.0" />
-			<property name="unusedClassMethods" value="com.liferay.portlet.asset.model.AssetRenderer|getPreviewPath|javax.portlet.PortletRequest javax.portlet.PortletResponse" />
 			<message key="method.unused" value="Method ''{0}'' no longer used in class ''{1}'' for version {2}" />
 		</module>
 		<module name="com.liferay.source.formatter.checkstyle.check.ValidatorIsNullCheck">

--- a/modules/util/source-formatter/src/main/resources/dependencies/upgrade-unused-method-names.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/upgrade-unused-method-names.json
@@ -1,12 +1,12 @@
 {
 	"upgradUnusedMethodNames": [
 		{
-			"branch": "7.0.x",
 			"className": "com.liferay.portlet.asset.model.AssetRenderer",
 			"methodName": "getPreviewPath",
 			"parameterNames": [
 				"javax.portlet.PortletRequest javax.portlet.PortletResponse"
-			]
+			],
+			"version": "7.0.x"
 		}
 	]
 }

--- a/modules/util/source-formatter/src/main/resources/dependencies/upgrade-unused-method-names.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/upgrade-unused-method-names.json
@@ -1,5 +1,5 @@
 {
-	"upgradUnusedMethodNames": [
+	"upgradeUnusedMethodNames": [
 		{
 			"className": "com.liferay.portlet.asset.model.AssetRenderer",
 			"methodName": "getPreviewPath",

--- a/modules/util/source-formatter/src/main/resources/dependencies/upgrade-unused-method-names.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/upgrade-unused-method-names.json
@@ -1,0 +1,12 @@
+{
+	"upgradUnusedMethodNames": [
+		{
+			"branch": "7.0.x",
+			"className": "com.liferay.portlet.asset.model.AssetRenderer",
+			"methodName": "getPreviewPath",
+			"parameterNames": [
+				"javax.portlet.PortletRequest javax.portlet.PortletResponse"
+			]
+		}
+	]
+}

--- a/modules/util/source-formatter/src/main/resources/dependencies/upgrade-unused-method-names.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/upgrade-unused-method-names.json
@@ -3,10 +3,8 @@
 		{
 			"className": "com.liferay.portlet.asset.model.AssetRenderer",
 			"methodName": "getPreviewPath",
-			"parameterNames": [
-				"javax.portlet.PortletRequest javax.portlet.PortletResponse"
-			],
-			"version": "7.0.x"
+			"parameterNames": "javax.portlet.PortletRequest javax.portlet.PortletResponse",
+			"version": "7.0"
 		}
 	]
 }

--- a/modules/util/source-formatter/src/main/resources/documentation/all_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/all_checks.markdown
@@ -403,6 +403,7 @@ UnwrappedVariableInfoCheck | [Bug Prevention](bug_prevention_checks.markdown#bug
 UpgradeDeprecatedAPICheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | .java | Finds calls to deprecated classes, constructors, fields or methods after an upgrade |
 UpgradeJavaCheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | .java | Performs upgrade checks for `java` files |
 UpgradeRemovedAPICheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | .java | Finds cases where calls are made to removed API after an upgrade. |
+UpgradeUnusedAPICheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Finds cases where calls are unused after an upgrade. |
 [ValidatorEqualsCheck](check/validator_equals_check.markdown#validatorequalscheck) | [Performance](performance_checks.markdown#performance-checks) | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Checks that there are no calls to `Validator.equals(Object, Object)`. |
 ValidatorIsNullCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Ensures that only variable of type `Long`, `Serializable` or `String` is passed to method `com.liferay.portal.kernel.util.Validator.isNull`. |
 VariableDeclarationAsUsedCheck | [Performance](performance_checks.markdown#performance-checks) | .java | Finds cases where a variable declaration can be inlined or moved closer to where it is used. |

--- a/modules/util/source-formatter/src/main/resources/documentation/java_source_processor_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/java_source_processor_checks.markdown
@@ -249,6 +249,7 @@ UnusedVariableCheck | [Performance](performance_checks.markdown#performance-chec
 UnwrappedVariableInfoCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Finds cases where the variable should be wrapped into an inner class in order to defer array elements initialization. |
 UpgradeDeprecatedAPICheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | Finds calls to deprecated classes, constructors, fields or methods after an upgrade |
 UpgradeRemovedAPICheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | Finds cases where calls are made to removed API after an upgrade. |
+UpgradeUnusedAPICheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | Finds cases where calls are unused after an upgrade. |
 [ValidatorEqualsCheck](check/validator_equals_check.markdown#validatorequalscheck) | [Performance](performance_checks.markdown#performance-checks) | Checks that there are no calls to `Validator.equals(Object, Object)`. |
 ValidatorIsNullCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Ensures that only variable of type `Long`, `Serializable` or `String` is passed to method `com.liferay.portal.kernel.util.Validator.isNull`. |
 VariableDeclarationAsUsedCheck | [Performance](performance_checks.markdown#performance-checks) | Finds cases where a variable declaration can be inlined or moved closer to where it is used. |

--- a/modules/util/source-formatter/src/main/resources/documentation/jsp_source_processor_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/jsp_source_processor_checks.markdown
@@ -107,6 +107,7 @@ TernaryOperatorCheck | [Styling](styling_checks.markdown#styling-checks) | Finds
 [UnnecessaryParenthesesCheck](https://checkstyle.sourceforge.io/config_coding.html#UnnecessaryParentheses) | [Styling](styling_checks.markdown#styling-checks) | Checks if unnecessary parentheses are used in a statement or expression. |
 UnnecessaryTypeCastCheck | [Performance](performance_checks.markdown#performance-checks) | Finds unnecessary Type Casting. |
 UnparameterizedClassCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Finds `Class` instantation without generic type. |
+UpgradeUnusedAPICheck | [Upgrade](upgrade_checks.markdown#upgrade-checks) | Finds cases where calls are unused after an upgrade. |
 [ValidatorEqualsCheck](check/validator_equals_check.markdown#validatorequalscheck) | [Performance](performance_checks.markdown#performance-checks) | Checks that there are no calls to `Validator.equals(Object, Object)`. |
 ValidatorIsNullCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Ensures that only variable of type `Long`, `Serializable` or `String` is passed to method `com.liferay.portal.kernel.util.Validator.isNull`. |
 [WhitespaceAfterCheck](https://checkstyle.sourceforge.io/config_whitespace.html#WhitespaceAfter) | [Styling](styling_checks.markdown#styling-checks) | Checks that a token is followed by whitespace, with the exception that it does not check for whitespace after the semicolon of an empty for iterator. |

--- a/modules/util/source-formatter/src/main/resources/documentation/upgrade_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/upgrade_checks.markdown
@@ -6,4 +6,5 @@ JSPUpgradeRemovedTagsCheck | .jsp, .jspf, .jspx, .tag, .tpl or .vm | Finds remov
 UpgradeDeprecatedAPICheck | .java | Finds calls to deprecated classes, constructors, fields or methods after an upgrade |
 UpgradeJavaCheck | .java | Performs upgrade checks for `java` files |
 UpgradeRemovedAPICheck | .java | Finds cases where calls are made to removed API after an upgrade. |
+UpgradeUnusedAPICheck | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Finds calls to unused class and methods after an upgrade |
 XMLUpgradeRemovedDefinitionsCheck | .action, .function, .jrxml, .macro, .pom, .project, .properties, .svg, .testcase, .toggle, .tpl, .wsdl, .xml or .xsd | Finds removed XML definitions when upgrading. |

--- a/modules/util/source-formatter/src/main/resources/documentation/upgrade_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/upgrade_checks.markdown
@@ -6,5 +6,5 @@ JSPUpgradeRemovedTagsCheck | .jsp, .jspf, .jspx, .tag, .tpl or .vm | Finds remov
 UpgradeDeprecatedAPICheck | .java | Finds calls to deprecated classes, constructors, fields or methods after an upgrade |
 UpgradeJavaCheck | .java | Performs upgrade checks for `java` files |
 UpgradeRemovedAPICheck | .java | Finds cases where calls are made to removed API after an upgrade. |
-UpgradeUnusedAPICheck | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Finds calls to unused class and methods after an upgrade |
+UpgradeUnusedAPICheck | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Finds cases where calls are unused after an upgrade. |
 XMLUpgradeRemovedDefinitionsCheck | .action, .function, .jrxml, .macro, .pom, .project, .properties, .svg, .testcase, .toggle, .tpl, .wsdl, .xml or .xsd | Finds removed XML definitions when upgrading. |


### PR DESCRIPTION
Enforce user to not use unused method when do upgrade.

For example:
https://github.com/LiferayCloud/service-upgrade-bot/blob/master/lugbot/code-upgrade/providers/src/main/resources/com/liferay/ide/upgrade/problems/core/internal/liferay70/BREAKING_CHANGES.markdown#changed-the-usage-of-asset-preview-

```
Changed the Usage of Asset Preview
Date: 2015-Mar-16
JIRA Ticket: LPS-53972
What changed?
Instead of directly including the JSP referenced by the AssetRenderer's getPreviewPath method to preview an asset, you now use a taglib tag.

Who is affected?
This affects developers who have written code that directly calls an AssetRenderer's getPreviewPath method to preview an asset.

How should I update my code?
JSP code that previews an asset by calling an AssetRenderer's getPreviewPath method, such as in the example code below, must be replaced:

<liferay-util:include
    page="<%= assetRenderer.getPreviewPath(liferayPortletRequest, liferayPortletResponse) %>"
    portletId="<%= assetRendererFactory.getPortletId() %>"
    servletContext="<%= application %>"
/>
To preview an asset, you should instead use the liferay-ui:asset-display tag, passing it an instance of the asset entry and an asset renderer preview template. Here's an example of using the tag:

<liferay-ui:asset-display
    assetEntry="<%= assetEntry %>"
    template="<%= AssetRenderer.TEMPLATE_PREVIEW %>"
/>
Why was this change made?
This change simplifies using asset previews.


```
