### PR TITLE
LPS-147036 Make JavaParser compatible with Java 11

### DIFF
--- a/modules/apps/commerce/commerce-channel-web/src/main/java/com/liferay/commerce/channel/web/internal/portlet/action/EditCommerceChannelMVCActionCommand.java
+++ b/modules/apps/commerce/commerce-channel-web/src/main/java/com/liferay/commerce/channel/web/internal/portlet/action/EditCommerceChannelMVCActionCommand.java
@@ -366,8 +366,7 @@ public class EditCommerceChannelMVCActionCommand extends BaseMVCActionCommand {
 			return;
 		}
 
-		FileEntry newFileEntry = _dlAppLocalService.getFileEntry(
-			fileEntryId);
+		FileEntry newFileEntry = _dlAppLocalService.getFileEntry(fileEntryId);
 
 		if (!Objects.equals(newFileEntry.getExtension(), "jrxml")) {
 			throw new FileExtensionException();
@@ -376,8 +375,7 @@ public class EditCommerceChannelMVCActionCommand extends BaseMVCActionCommand {
 		if (existingFileEntry == null) {
 			String fileName = newFileEntry.getFileName();
 
-			int extensionIndex = fileName.indexOf(
-				newFileEntry.getExtension());
+			int extensionIndex = fileName.indexOf(newFileEntry.getExtension());
 
 			String formattedFileName = StringBundler.concat(
 				fileName.substring(0, extensionIndex - 1), StringPool.UNDERLINE,
@@ -389,12 +387,10 @@ public class EditCommerceChannelMVCActionCommand extends BaseMVCActionCommand {
 					"ORDER_PRINT_TEMPLATE", commerceChannel.getUserId(),
 					commerceChannel.getGroupId(),
 					DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-					newFileEntry.getFileName(),
-					newFileEntry.getMimeType(), formattedFileName,
-					StringPool.BLANK, StringPool.BLANK,
-					newFileEntry.getContentStream(),
-					newFileEntry.getSize(), null, null,
-					new ServiceContext());
+					newFileEntry.getFileName(), newFileEntry.getMimeType(),
+					formattedFileName, StringPool.BLANK, StringPool.BLANK,
+					newFileEntry.getContentStream(), newFileEntry.getSize(),
+					null, null, new ServiceContext());
 			}
 			finally {
 				_dlAppLocalService.deleteFileEntry(fileEntryId);
@@ -402,16 +398,12 @@ public class EditCommerceChannelMVCActionCommand extends BaseMVCActionCommand {
 		}
 		else {
 			_dlAppLocalService.updateFileEntry(
-				commerceChannel.getUserId(),
-				existingFileEntry.getFileEntryId(),
-				newFileEntry.getFileName(),
-				newFileEntry.getMimeType(),
+				commerceChannel.getUserId(), existingFileEntry.getFileEntryId(),
+				newFileEntry.getFileName(), newFileEntry.getMimeType(),
 				existingFileEntry.getTitle(),
 				existingFileEntry.getDescription(), StringPool.BLANK,
-				DLVersionNumberIncrease.NONE,
-				newFileEntry.getContentStream(),
-				newFileEntry.getSize(), null, null,
-				new ServiceContext());
+				DLVersionNumberIncrease.NONE, newFileEntry.getContentStream(),
+				newFileEntry.getSize(), null, null, new ServiceContext());
 		}
 	}
 

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/field/business/type/ObjectFieldBusinessTypeServicesTracker.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/field/business/type/ObjectFieldBusinessTypeServicesTracker.java
@@ -15,7 +15,6 @@
 package com.liferay.object.field.business.type;
 
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 
 /**

--- a/modules/util/portal-tools-java-parser/src/main/java/com/liferay/portal/tools/java/parser/JavaLambdaParameter.java
+++ b/modules/util/portal-tools-java-parser/src/main/java/com/liferay/portal/tools/java/parser/JavaLambdaParameter.java
@@ -15,6 +15,9 @@
 package com.liferay.portal.tools.java.parser;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+
+import java.util.List;
 
 /**
  * @author Hugo Huijser
@@ -22,7 +25,16 @@ import com.liferay.petra.string.StringBundler;
 public class JavaLambdaParameter extends BaseJavaTerm {
 
 	public JavaLambdaParameter(String name) {
+		this(name, null, null);
+	}
+
+	public JavaLambdaParameter(
+		String name, List<JavaAnnotation> javaAnnotations,
+		List<JavaSimpleValue> modifiers) {
+
 		_name = new JavaSimpleValue(name);
+		_javaAnnotations = javaAnnotations;
+		_modifiers = modifiers;
 	}
 
 	public boolean hasJavaType() {
@@ -47,9 +59,29 @@ public class JavaLambdaParameter extends BaseJavaTerm {
 
 		StringBundler sb = new StringBundler();
 
+		for (int i = 0; i < _javaAnnotations.size(); i++) {
+			if (i == 0) {
+				appendNewLine(
+					sb, _javaAnnotations.get(i), indent, prefix, " ",
+					maxLineLength);
+
+				prefix = StringPool.BLANK;
+			}
+			else {
+				appendNewLine(
+					sb, _javaAnnotations.get(i), indent, maxLineLength);
+			}
+		}
+
 		sb.append(indent);
 
 		indent = "\t" + indent;
+
+		if (!_modifiers.isEmpty()) {
+			indent = append(sb, _modifiers, indent, prefix, " ", maxLineLength);
+
+			prefix = StringPool.BLANK;
+		}
 
 		indent = append(sb, _javaType, indent, prefix, " ", maxLineLength);
 
@@ -58,7 +90,9 @@ public class JavaLambdaParameter extends BaseJavaTerm {
 		return sb.toString();
 	}
 
+	private List<JavaAnnotation> _javaAnnotations;
 	private JavaType _javaType;
+	private List<JavaSimpleValue> _modifiers;
 	private final JavaSimpleValue _name;
 
 }

--- a/modules/util/portal-tools-java-parser/src/main/java/com/liferay/portal/tools/java/parser/JavaTryStatement.java
+++ b/modules/util/portal-tools-java-parser/src/main/java/com/liferay/portal/tools/java/parser/JavaTryStatement.java
@@ -23,17 +23,15 @@ import java.util.List;
  */
 public class JavaTryStatement extends BaseJavaTerm {
 
-	public void setResourceJavaVariableDefinitions(
-		List<JavaVariableDefinition> resourceJavaVariableDefinitions) {
-
-		_resourceJavaVariableDefinitions = resourceJavaVariableDefinitions;
+	public void setResourceJavaTerms(List<JavaTerm> resourceJavaTerms) {
+		_resourceJavaTerms = resourceJavaTerms;
 	}
 
 	@Override
 	public String toString(
 		String indent, String prefix, String suffix, int maxLineLength) {
 
-		if (_resourceJavaVariableDefinitions == null) {
+		if (_resourceJavaTerms == null) {
 			return StringBundler.concat(indent, prefix, "try", suffix);
 		}
 
@@ -44,12 +42,12 @@ public class JavaTryStatement extends BaseJavaTerm {
 		indent = "\t" + indent;
 
 		append(
-			sb, _resourceJavaVariableDefinitions, "; ", indent,
-			prefix + "try (", ")" + suffix, maxLineLength);
+			sb, _resourceJavaTerms, "; ", indent, prefix + "try (",
+			")" + suffix, maxLineLength);
 
 		return sb.toString();
 	}
 
-	private List<JavaVariableDefinition> _resourceJavaVariableDefinitions;
+	private List<JavaTerm> _resourceJavaTerms;
 
 }

--- a/modules/util/portal-tools-java-parser/src/main/java/com/liferay/portal/tools/java/parser/JavaType.java
+++ b/modules/util/portal-tools-java-parser/src/main/java/com/liferay/portal/tools/java/parser/JavaType.java
@@ -15,7 +15,6 @@
 package com.liferay.portal.tools.java.parser;
 
 import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.NaturalOrderStringComparator;
 
 import java.util.List;
@@ -26,14 +25,7 @@ import java.util.List;
 public class JavaType extends BaseJavaTerm implements Comparable<JavaType> {
 
 	public JavaType(String name, int arrayDimension) {
-		this(name, null, arrayDimension);
-	}
-
-	public JavaType(
-		String name, List<JavaAnnotation> javaAnnotations, int arrayDimension) {
-
 		_name = new JavaSimpleValue(name);
-		_javaAnnotations = javaAnnotations;
 		_arrayDimension = arrayDimension;
 	}
 
@@ -97,16 +89,6 @@ public class JavaType extends BaseJavaTerm implements Comparable<JavaType> {
 
 		indent = "\t" + indent;
 
-		if (ListUtil.isNotEmpty(_javaAnnotations) &&
-			!appendSingleLine(
-				sb, _javaAnnotations, " ", "", " ", maxLineLength)) {
-
-			append(sb, _javaAnnotations, " ", indent, "", "", maxLineLength);
-
-			sb.append("\n");
-			sb.append(indent.substring(1));
-		}
-
 		if ((_genericJavaTypes == null) && (_lowerBoundJavaTypes == null) &&
 			(_upperBoundJavaTypes == null)) {
 
@@ -140,7 +122,7 @@ public class JavaType extends BaseJavaTerm implements Comparable<JavaType> {
 					maxLineLength, false);
 			}
 			else {
-				indent = append(
+				append(
 					sb, _lowerBoundJavaTypes, " & ", indent, " super ", suffix,
 					maxLineLength);
 			}
@@ -163,7 +145,6 @@ public class JavaType extends BaseJavaTerm implements Comparable<JavaType> {
 
 	private final int _arrayDimension;
 	private List<JavaType> _genericJavaTypes;
-	private final List<JavaAnnotation> _javaAnnotations;
 	private List<JavaType> _lowerBoundJavaTypes;
 	private final JavaSimpleValue _name;
 	private List<JavaType> _upperBoundJavaTypes;

--- a/modules/util/portal-tools-java-parser/src/main/java/com/liferay/portal/tools/java/parser/util/JavaParserUtil.java
+++ b/modules/util/portal-tools-java-parser/src/main/java/com/liferay/portal/tools/java/parser/util/JavaParserUtil.java
@@ -1361,8 +1361,14 @@ public class JavaParserUtil {
 		for (DetailAST parameterDefinitionDetailAST :
 				parameterDefinitionDetailASTList) {
 
+			DetailAST modifiersDetailAST =
+				parameterDefinitionDetailAST.findFirstToken(
+					TokenTypes.MODIFIERS);
+
 			JavaLambdaParameter javaLambdaParameter = new JavaLambdaParameter(
-				_getName(parameterDefinitionDetailAST));
+				_getName(parameterDefinitionDetailAST),
+				_parseJavaAnnotations(modifiersDetailAST),
+				_parseModifiers(modifiersDetailAST));
 
 			DetailAST typeDetailAST =
 				parameterDefinitionDetailAST.findFirstToken(TokenTypes.TYPE);
@@ -1747,26 +1753,9 @@ public class JavaParserUtil {
 			return null;
 		}
 
-		List<JavaAnnotation> javaAnnotations = new ArrayList<>();
-
-		if (detailAST.getType() == TokenTypes.TYPE) {
-			DetailAST parentDetailAST = detailAST.getParent();
-			DetailAST previousSiblingDetailAST = detailAST.getPreviousSibling();
-
-			if ((parentDetailAST.getType() == TokenTypes.PARAMETER_DEF) &&
-				(previousSiblingDetailAST != null) &&
-				(previousSiblingDetailAST.getType() == TokenTypes.MODIFIERS)) {
-
-				javaAnnotations = _parseJavaAnnotations(
-					previousSiblingDetailAST);
-			}
-		}
-
 		DetailAST childDetailAST = detailAST.getFirstChild();
 
 		if (childDetailAST.getType() == TokenTypes.ANNOTATIONS) {
-			javaAnnotations = _parseJavaAnnotations(childDetailAST);
-
 			childDetailAST = childDetailAST.getNextSibling();
 		}
 
@@ -1778,8 +1767,7 @@ public class JavaParserUtil {
 
 		FullIdent typeIdent = FullIdent.createFullIdent(childDetailAST);
 
-		JavaType javaType = new JavaType(
-			typeIdent.getText(), javaAnnotations, arrayDimension);
+		JavaType javaType = new JavaType(typeIdent.getText(), arrayDimension);
 
 		DetailAST typeInfoDetailAST = childDetailAST;
 

--- a/modules/util/portal-tools-java-parser/src/main/java/com/liferay/portal/tools/java/parser/util/JavaParserUtil.java
+++ b/modules/util/portal-tools-java-parser/src/main/java/com/liferay/portal/tools/java/parser/util/JavaParserUtil.java
@@ -1725,22 +1725,19 @@ public class JavaParserUtil {
 			return javaTryStatement;
 		}
 
-		List<JavaVariableDefinition> resourceJavaVariableDefinitions =
-			new ArrayList<>();
+		List<JavaTerm> resourceJavaTerms = new ArrayList<>();
 
 		DetailAST resourcesDetailAST = firstChildDetailAST.findFirstToken(
 			TokenTypes.RESOURCES);
 
 		List<DetailAST> resourceDetailASTList = DetailASTUtil.getAllChildTokens(
-			resourcesDetailAST, false, TokenTypes.RESOURCE);
+			resourcesDetailAST, false, TokenTypes.RESOURCE, TokenTypes.IDENT);
 
 		for (DetailAST resourceDetailAST : resourceDetailASTList) {
-			resourceJavaVariableDefinitions.add(
-				_parseJavaVariableDefinition(resourceDetailAST));
+			resourceJavaTerms.add(_parseResourceJavaTerm(resourceDetailAST));
 		}
 
-		javaTryStatement.setResourceJavaVariableDefinitions(
-			resourceJavaVariableDefinitions);
+		javaTryStatement.setResourceJavaTerms(resourceJavaTerms);
 
 		return javaTryStatement;
 	}
@@ -1932,6 +1929,16 @@ public class JavaParserUtil {
 
 			childDetailAST = childDetailAST.getNextSibling();
 		}
+	}
+
+	private static JavaTerm _parseResourceJavaTerm(
+		DetailAST resourceDetailAST) {
+
+		if (resourceDetailAST.findFirstToken(TokenTypes.MODIFIERS) != null) {
+			return _parseJavaVariableDefinition(resourceDetailAST);
+		}
+
+		return new JavaSimpleValue(resourceDetailAST.getText());
 	}
 
 	private static final int[] _SIMPLE_TYPES = {


### PR DESCRIPTION
__📝 Notes:__
Ticket: <https://issues.liferay.com/browse/LPS-147036>

Currently, the `JavaParser` in `portal-tools-java-parser` does not completely support Java 11 code. Namely, there are two language features that the parser does not currently support:

__External declaration of resource variables in try-with-resources block (Java 9)__

- You can now initialize resource variables outside the try-with-resources block.

```java
FileReader fileReader = new FileReader(args[0]);

try (fileReader) {
    while (true) {
        int ch = fileReader.read();

        if (ch == -1) {
            break;
        }
    }
}
```

__Usage of the `var` keyword in lambda expressions (Java 11)__
 
- As a result of this feature, you can now add annotations and modifiers to parameters in lambda expressions.

```java
UnaryOperator<String> makeItLoud = (@NotNull final var s) -> {
        return s + "!";
    };

String loudHello = makeItLoud.apply("Hello");
```

For more information, see the following documentation links:

- <https://docs.oracle.com/javase/9/language/toc.htm#JSLAN-GUID-B06D7006-D9F4-42F8-AD21-BF861747EDCF>
- <https://docs.oracle.com/en/java/javase/11/language/local-variable-type-inference.html>

The Checkstyle Java parser that we use already supports Java 11, so there is no need to upgrade Checkstyle. 

Let me know if you have any questions/thoughts.