### PR TITLE
LPS-162325 Always specify 'configurationPolicy = ConfigurationPolicy.REQUIRE' when a class extends 'BaseAuthVerifierPipelineConfigurator'

### DIFF
--- a/modules/util/source-formatter/source-formatter.properties
+++ b/modules/util/source-formatter/source-formatter.properties
@@ -11,8 +11,6 @@
     checkstyle.ChainingCheck.allowedClassNames=\
         Comparator
 
-    checkstyle.ExceptionMapperAnnotationCheck.enabled=true
-
     checkstyle.RedundantLogCheck.enabled=true
 
     source.check.JavaClassNameCheck.enabled=false

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/ComponentAnnotationCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/ComponentAnnotationCheck.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 /**
  * @author Simon Jiang
  */
-public class ExceptionMapperAnnotationCheck extends BaseCheck {
+public class ComponentAnnotationCheck extends BaseCheck {
 
 	@Override
 	public int[] getDefaultTokens() {
@@ -38,23 +38,29 @@ public class ExceptionMapperAnnotationCheck extends BaseCheck {
 	protected void doVisitToken(DetailAST detailAST) {
 		List<String> importNames = getImportNames(detailAST);
 
-		if (!importNames.contains("javax.ws.rs.ext.ExceptionMapper") ||
+		DetailAST parentDetailAST = detailAST.getParent();
+
+		if ((parentDetailAST != null) ||
 			!importNames.contains(
 				"org.osgi.service.component.annotations.Component")) {
 
 			return;
 		}
 
-		DetailAST parentDetailAST = detailAST.getParent();
-
-		if (parentDetailAST != null) {
-			return;
-		}
-
 		DetailAST annotationDetailAST = AnnotationUtil.getAnnotation(
 			detailAST, "Component");
 
-		if ((annotationDetailAST == null) ||
+		if (annotationDetailAST == null) {
+			return;
+		}
+
+		_checkOSGiJaxrsName(annotationDetailAST, importNames);
+	}
+
+	private void _checkOSGiJaxrsName(
+		DetailAST annotationDetailAST, List<String> importNames) {
+
+		if (!importNames.contains("javax.ws.rs.ext.ExceptionMapper") ||
 			!_isExceptionMapperService(annotationDetailAST)) {
 
 			return;

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/ComponentAnnotationCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/ComponentAnnotationCheck.java
@@ -15,6 +15,7 @@
 package com.liferay.source.formatter.checkstyle.check;
 
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.poshi.runner.util.StringUtil;
 
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
@@ -68,7 +69,21 @@ public class ComponentAnnotationCheck extends BaseCheck {
 			return;
 		}
 
-		String extendsClassName = getName(extendsClauseDetailAST);
+		DetailAST firstChildDetailAST = extendsClauseDetailAST.getFirstChild();
+
+		String extendsClassName = null;
+
+		if (firstChildDetailAST.getType() == TokenTypes.IDENT) {
+			extendsClassName = getName(extendsClauseDetailAST);
+		}
+		else if (firstChildDetailAST.getType() == TokenTypes.DOT) {
+			FullIdent fullIdent = FullIdent.createFullIdent(
+				firstChildDetailAST);
+
+			String[] parts = StringUtil.split(fullIdent.getText(), "\\.");
+
+			extendsClassName = parts[parts.length - 1];
+		}
 
 		if (!extendsClassName.equals("BaseAuthVerifierPipelineConfigurator")) {
 			return;

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/ComponentAnnotationCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/ComponentAnnotationCheck.java
@@ -14,8 +14,8 @@
 
 package com.liferay.source.formatter.checkstyle.check;
 
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.poshi.runner.util.StringUtil;
 
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/ComponentAnnotationCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/ComponentAnnotationCheck.java
@@ -54,7 +54,46 @@ public class ComponentAnnotationCheck extends BaseCheck {
 			return;
 		}
 
+		_checkConfigurationPolicy(detailAST, annotationDetailAST);
 		_checkOSGiJaxrsName(annotationDetailAST, importNames);
+	}
+
+	private void _checkConfigurationPolicy(
+		DetailAST detailAST, DetailAST annotationDetailAST) {
+
+		DetailAST extendsClauseDetailAST = detailAST.findFirstToken(
+			TokenTypes.EXTENDS_CLAUSE);
+
+		if (extendsClauseDetailAST == null) {
+			return;
+		}
+
+		String extendsClassName = getName(extendsClauseDetailAST);
+
+		if (!extendsClassName.equals("BaseAuthVerifierPipelineConfigurator")) {
+			return;
+		}
+
+		DetailAST annotationMemberValuePairDetailAST =
+			getAnnotationMemberValuePairDetailAST(
+				annotationDetailAST, "configurationPolicy");
+
+		if (annotationMemberValuePairDetailAST != null) {
+			DetailAST expressionDetailAST =
+				annotationMemberValuePairDetailAST.findFirstToken(
+					TokenTypes.EXPR);
+
+			FullIdent expressionIdent = FullIdent.createFullIdentBelow(
+				expressionDetailAST);
+
+			String annotationMemberValue = expressionIdent.getText();
+
+			if (annotationMemberValue.equals("ConfigurationPolicy.REQUIRE")) {
+				return;
+			}
+		}
+
+		log(annotationDetailAST, _MSG_INCORRECT_CONFIGURATION_POLICY);
 	}
 
 	private void _checkOSGiJaxrsName(
@@ -151,6 +190,9 @@ public class ComponentAnnotationCheck extends BaseCheck {
 
 		return true;
 	}
+
+	private static final String _MSG_INCORRECT_CONFIGURATION_POLICY =
+		"configuration.policy.incorrect";
 
 	private static final String _MSG_INCORRECT_OSGI_JAXRS_MAME =
 		"osgi.jaxrs.name.incorrect";

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/ComponentAnnotationCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/ComponentAnnotationCheck.java
@@ -73,16 +73,16 @@ public class ComponentAnnotationCheck extends BaseCheck {
 
 		String extendsClassName = null;
 
-		if (firstChildDetailAST.getType() == TokenTypes.IDENT) {
-			extendsClassName = getName(extendsClauseDetailAST);
-		}
-		else if (firstChildDetailAST.getType() == TokenTypes.DOT) {
+		if (firstChildDetailAST.getType() == TokenTypes.DOT) {
 			FullIdent fullIdent = FullIdent.createFullIdent(
 				firstChildDetailAST);
 
 			String[] parts = StringUtil.split(fullIdent.getText(), "\\.");
 
 			extendsClassName = parts[parts.length - 1];
+		}
+		else if (firstChildDetailAST.getType() == TokenTypes.IDENT) {
+			extendsClassName = getName(extendsClauseDetailAST);
 		}
 
 		if (!extendsClassName.equals("BaseAuthVerifierPipelineConfigurator")) {

--- a/modules/util/source-formatter/src/main/resources/checkstyle.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle.xml
@@ -274,6 +274,11 @@
 			<property name="enabled" value="false" />
 			<message key="company.local.service.use" value="Use ''CompanyLocalService.{0}'' when iterating over ''{1}''" />
 		</module>
+		<module name="com.liferay.source.formatter.checkstyle.check.ComponentAnnotationCheck">
+			<property name="category" value="Bug Prevention" />
+			<property name="description" value="Performs several checks on classes with @Component annotation." />
+			<message key="osgi.jaxrs.name.incorrect" value="The value of ''osgi.jaxrs.name'' should end with ''{0}''" />
+		</module>
 		<module name="com.liferay.source.formatter.checkstyle.check.ConcatCheck">
 			<property name="category" value="Performance" />
 			<property name="description" value="Checks for correct use of `StringBundler.concat`." />
@@ -364,11 +369,6 @@
 			<property name="category" value="Performance" />
 			<property name="description" value="Finds private methods that throw unnecessary exception." />
 			<message key="exception.unnecessary" value="Method ''{0}'' throws unnecessary {1}. All methods calling ''{0}'' throw ''Exception''." />
-		</module>
-		<module name="com.liferay.source.formatter.checkstyle.check.ExceptionMapperAnnotationCheck">
-			<property name="category" value="Bug Prevention" />
-			<property name="description" value="Performs several checks on classes with @Reference annotation." />
-			<message key="osgi.jaxrs.name.incorrect" value="The value of ''osgi.jaxrs.name'' should end with ''{0}''" />
 		</module>
 		<module name="com.liferay.source.formatter.checkstyle.check.ExceptionMessageCheck">
 			<property name="category" value="Styling" />

--- a/modules/util/source-formatter/src/main/resources/checkstyle.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle.xml
@@ -369,7 +369,6 @@
 			<property name="category" value="Bug Prevention" />
 			<property name="description" value="Performs several checks on classes with @Reference annotation." />
 			<message key="osgi.jaxrs.name.incorrect" value="The value of ''osgi.jaxrs.name'' should end with ''{0}''" />
-			<property name="enabled" value="false" />
 		</module>
 		<module name="com.liferay.source.formatter.checkstyle.check.ExceptionMessageCheck">
 			<property name="category" value="Styling" />

--- a/modules/util/source-formatter/src/main/resources/checkstyle.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle.xml
@@ -277,6 +277,7 @@
 		<module name="com.liferay.source.formatter.checkstyle.check.ComponentAnnotationCheck">
 			<property name="category" value="Bug Prevention" />
 			<property name="description" value="Performs several checks on classes with @Component annotation." />
+			<message key="configuration.policy.incorrect" value="Always specify ''configurationPolicy = ConfigurationPolicy.REQUIRE'' when a classs extends ''BaseAuthVerifierPipelineConfigurator''" />
 			<message key="osgi.jaxrs.name.incorrect" value="The value of ''osgi.jaxrs.name'' should end with ''{0}''" />
 		</module>
 		<module name="com.liferay.source.formatter.checkstyle.check.ConcatCheck">

--- a/modules/util/source-formatter/src/main/resources/documentation/all_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/all_checks.markdown
@@ -46,6 +46,7 @@ CSSPropertiesOrderCheck | [Styling](styling_checks.markdown#styling-checks) | .c
 CodeownersWhitespaceCheck | [Styling](styling_checks.markdown#styling-checks) | CODEOWNERS | Finds missing and unnecessary whitespace in `CODEOWNERS` files. |
 [CompanyIterationCheck](check/company_iteration_check.markdown#companyiterationcheck) | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Checks that `CompanyLocalService.forEachCompany` or `CompanyLocalService.forEachCompanyId` is used when iterating over companies |
 CompatClassImportsCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Checks that classes are imported from `compat` modules, when possible. |
+ComponentAnnotationCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .java | Performs several checks on classes with @Component annotation. |
 ConcatCheck | [Performance](performance_checks.markdown#performance-checks) | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Checks for correct use of `StringBundler.concat`. |
 ConfigDefinitionKeysCheck | [Styling](styling_checks.markdown#styling-checks) | .cfg or .config | Sorts definition keys in `.config` files. |
 ConfigWhitespaceCheck | [Styling](styling_checks.markdown#styling-checks) | .cfg or .config | Finds missing and unnecessary whitespace. |
@@ -67,7 +68,6 @@ EnumConstantDividerCheck | [Styling](styling_checks.markdown#styling-checks) | .
 EnumConstantOrderCheck | [Styling](styling_checks.markdown#styling-checks) | .java | Checks the order of enum constants. |
 EqualClauseIfStatementsCheck | [Styling](styling_checks.markdown#styling-checks) | .java | Finds consecutive if-statements with identical clauses. |
 [ExceptionCheck](check/exception_check.markdown#exceptioncheck) | [Performance](performance_checks.markdown#performance-checks) | .java | Finds private methods that throw unnecessary exception. |
-ExceptionMapperAnnotationCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .java | Performs several checks on classes with @Reference annotation. |
 [ExceptionMessageCheck](check/message_check.markdown#messagecheck) | [Styling](styling_checks.markdown#styling-checks) | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Validates messages that are passed to exceptions. |
 ExceptionPrintStackTraceCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .java | Avoid using printStackTrace. |
 ExceptionVariableNameCheck | [Naming Conventions](naming_conventions_checks.markdown#naming-conventions-checks) | .java | Validates variable names that have type `*Exception`. |

--- a/modules/util/source-formatter/src/main/resources/documentation/bug_prevention_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/bug_prevention_checks.markdown
@@ -24,11 +24,11 @@ CQLKeywordCheck | .cql | Checks that Cassandra keywords are upper case. |
 [CodeownersFileLocationCheck](check/codeowners_file_location_check.markdown#codeownersfilelocationcheck) | CODEOWNERS | Checks that `CODEOWNERS` files are located in `.github` directory. |
 [CompanyIterationCheck](check/company_iteration_check.markdown#companyiterationcheck) | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Checks that `CompanyLocalService.forEachCompany` or `CompanyLocalService.forEachCompanyId` is used when iterating over companies |
 CompatClassImportsCheck | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Checks that classes are imported from `compat` modules, when possible. |
+ComponentAnnotationCheck | .java | Performs several checks on classes with @Component annotation. |
 ConsumerTypeAnnotationCheck | .java | Performs several checks on classes with @ConsumerType annotation. |
 DTOEnumCreationCheck | .java | Checks the creation of DTO enum. |
 DeprecatedAPICheck | .java | Finds calls to deprecated classes, constructors, fields or methods. |
 EmptyConstructorCheck | .java | Finds unnecessary empty constructors. |
-ExceptionMapperAnnotationCheck | .java | Performs several checks on classes with @Reference annotation. |
 ExceptionPrintStackTraceCheck | .java | Avoid using printStackTrace. |
 FactoryCheck | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Finds cases where `*Factory` should be used when creating new instances of an object. |
 FilterStringWhitespaceCheck | .java | Finds missing and unnecessary whitespace in the value of the filter string in `ServiceTrackerFactory.open` or `WaiterUtil.waitForFilter`. |

--- a/modules/util/source-formatter/src/main/resources/documentation/java_source_processor_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/java_source_processor_checks.markdown
@@ -17,6 +17,7 @@ AssignAsUsedCheck | [Performance](performance_checks.markdown#performance-checks
 [ChainingCheck](check/chaining_check.markdown#chainingcheck) | [Styling](styling_checks.markdown#styling-checks) | Checks that chaining is only applied on certain types and methods. |
 [CompanyIterationCheck](check/company_iteration_check.markdown#companyiterationcheck) | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Checks that `CompanyLocalService.forEachCompany` or `CompanyLocalService.forEachCompanyId` is used when iterating over companies |
 CompatClassImportsCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Checks that classes are imported from `compat` modules, when possible. |
+ComponentAnnotationCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Performs several checks on classes with @Component annotation. |
 ConcatCheck | [Performance](performance_checks.markdown#performance-checks) | Checks for correct use of `StringBundler.concat`. |
 ConstantNameCheck | [Naming Conventions](naming_conventions_checks.markdown#naming-conventions-checks) | Checks that variable names of constants follow correct naming rules. |
 ConstructorGlobalVariableDeclarationCheck | [Performance](performance_checks.markdown#performance-checks) | Checks that initial values of global variables are not set in the constructor. |
@@ -34,7 +35,6 @@ EnumConstantDividerCheck | [Styling](styling_checks.markdown#styling-checks) | F
 EnumConstantOrderCheck | [Styling](styling_checks.markdown#styling-checks) | Checks the order of enum constants. |
 EqualClauseIfStatementsCheck | [Styling](styling_checks.markdown#styling-checks) | Finds consecutive if-statements with identical clauses. |
 [ExceptionCheck](check/exception_check.markdown#exceptioncheck) | [Performance](performance_checks.markdown#performance-checks) | Finds private methods that throw unnecessary exception. |
-ExceptionMapperAnnotationCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Performs several checks on classes with @Reference annotation. |
 [ExceptionMessageCheck](check/message_check.markdown#messagecheck) | [Styling](styling_checks.markdown#styling-checks) | Validates messages that are passed to exceptions. |
 ExceptionPrintStackTraceCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Avoid using printStackTrace. |
 ExceptionVariableNameCheck | [Naming Conventions](naming_conventions_checks.markdown#naming-conventions-checks) | Validates variable names that have type `*Exception`. |

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -213,8 +213,6 @@
 
     checkstyle.EmptyConstructorCheck.enabled=true
 
-    checkstyle.ExceptionMapperAnnotationCheck.enabled=true
-
     checkstyle.FactoryCheck.enforceFactoryClassNames=\
         com.liferay.portal.kernel.service.permission.ModelPermissions:com.liferay.portal.kernel.service.permission.ModelPermissionsFactory
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-162325

See https://github.com/brianchandotcom/liferay-portal/pull/120271