### PR TITLE
LPS-163638 Fix missing language key

### DIFF
--- a/modules/apps/site-navigation/site-navigation-language-web/src/main/resources/META-INF/resources/portal_settings/locale_friendly_url.jsp
+++ b/modules/apps/site-navigation/site-navigation-language-web/src/main/resources/META-INF/resources/portal_settings/locale_friendly_url.jsp
@@ -26,9 +26,9 @@ SiteNavigationLocaleFriendlyURLConfiguration siteNavigationLocaleFriendlyURLConf
 
 		<aui:select label="site-navigation-locale-friendly-url-configuration-name" name="localePrependFriendlyURLStyle" type="text" value="<%= Validator.isNotNull(siteNavigationLocaleFriendlyURLConfiguration.localeFriendlyURL()) ? siteNavigationLocaleFriendlyURLConfiguration.localeFriendlyURL() : PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE %>">
 			<aui:option label="locale-is-not-automatically-prepended-to-a-url" value="0" />
-			<aui:option label="locale-is-automatically-prepended-to-a-url-when-the-requested-locale-is-not-the-default-user-locale" value="1" />
+			<aui:option label="locale-is-automatically-prepended-to-a-url-when-the-requested-locale-is-not-the-default-locale" value="1" />
 			<aui:option label="locale-is-automatically-prepended-to-every-url" value="2" />
-			<aui:option label="locale-is-automatically-prepended-to-a-url-when-the-requested-locale-is-not-default-user-locale" value="3" />
+			<aui:option label="locale-is-automatically-prepended-to-a-url-when-the-requested-locale-is-not-the-default-user-locale" value="3" />
 		</aui:select>
 	</div>
 </div>


### PR DESCRIPTION
SF issue:
`Missing language key 'locale-is-automatically-prepended-to-a-url-when-the-requested-locale-is-not-default-user-locale': /home/alan/liferay_code/master/liferay-portal/modules/apps/site-navigation/site-navigation-language-web/src/main/resources/META-INF/resources/portal_settings/locale_friendly_url.jsp (SourceCheck:JSPLanguageKeysCheck)
`

See https://github.com/liferay/liferay-portal/commit/8a10eb06a659e50e57783ccf4b5c9aa2c1f36293