### PR TITLE
LPS-166801 Improve logic to avoid revealing security vulnerabilities with commit message

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -7493,7 +7493,6 @@ information. Make sure to commit in all build services results.
 							<property name="source.fail.on.has.warning" value="true" />
 							<property name="source.print.errors" value="false" />
 							<property name="source.use.properties" value="false" />
-							<property name="validate.commit.messages" value="true" />
 						</ant>
 					</then>
 					<else>
@@ -7507,7 +7506,6 @@ information. Make sure to commit in all build services results.
 							<property name="source.fail.on.has.warning" value="true" />
 							<property name="source.print.errors" value="false" />
 							<property name="source.use.properties" value="false" />
-							<property name="validate.commit.messages" value="true" />
 						</ant>
 					</else>
 				</if>

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/SourceFormatter.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/SourceFormatter.java
@@ -1281,7 +1281,7 @@ public class SourceFormatter {
 
 		for (String commitMessage : commitMessages) {
 			for (String keyword :
-					_getPropertyValues("vulnerability.keywords")) {
+					_getPropertyValues("git.commit.vulnerability.keywords")) {
 
 				Pattern pattern = Pattern.compile(
 					"\\b_*(" + keyword + ")_*\\b", Pattern.CASE_INSENSITIVE);

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/SourceFormatter.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/SourceFormatter.java
@@ -1291,8 +1291,8 @@ public class SourceFormatter {
 				if (matcher.find()) {
 					throw new Exception(
 						StringBundler.concat(
-							"The commit '", commitMessage,
-							"' contains the word '", keyword,
+							"Found formatting issues:\n", "The commit '",
+							commitMessage, "' contains the word '", keyword,
 							"', which could reveal potential security ",
 							"vulnerablities."));
 				}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/SourceFormatter.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/SourceFormatter.java
@@ -101,6 +101,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * @author Hugo Huijser
@@ -1277,9 +1279,26 @@ public class SourceFormatter {
 			commitMessages, _getPropertyValues("jira.project.keys"));
 		JIRAUtil.validateJIRATicketIds(commitMessages, 20);
 
-		JIRAUtil.validateJIRASecurityKeywords(
-			commitMessages,
-			_getPropertyValues("jira.security.vulnerability.keywords"));
+		for (String commitMessage : commitMessages) {
+			for (String keyword :
+					_getPropertyValues(
+						"jira.security.vulnerability.keywords")) {
+
+				Pattern pattern = Pattern.compile(
+					"\\b_*(" + keyword + ")_*\\b", Pattern.CASE_INSENSITIVE);
+
+				Matcher matcher = pattern.matcher(commitMessage);
+
+				if (matcher.find()) {
+					throw new Exception(
+						StringBundler.concat(
+							"The commit '", commitMessage,
+							"' contains the word '", keyword,
+							"', which could reveal potential security ",
+							"vulnerablities."));
+				}
+			}
+		}
 	}
 
 	private static final String _PROPERTIES_FILE_NAME =

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/SourceFormatter.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/SourceFormatter.java
@@ -1294,7 +1294,9 @@ public class SourceFormatter {
 							"Found formatting issues:\n", "The commit '",
 							commitMessage, "' contains the word '", keyword,
 							"', which could reveal potential security ",
-							"vulnerablities."));
+							"vulnerablities. Please see the vulnerability ",
+							"keywords that are specified in source-formatter.",
+							"properties in the liferay-portal repository."));
 				}
 			}
 		}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/SourceFormatter.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/SourceFormatter.java
@@ -1281,8 +1281,7 @@ public class SourceFormatter {
 
 		for (String commitMessage : commitMessages) {
 			for (String keyword :
-					_getPropertyValues(
-						"jira.security.vulnerability.keywords")) {
+					_getPropertyValues("vulnerability.keywords")) {
 
 				Pattern pattern = Pattern.compile(
 					"\\b_*(" + keyword + ")_*\\b", Pattern.CASE_INSENSITIVE);

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/SourceFormatter.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/SourceFormatter.java
@@ -1279,7 +1279,7 @@ public class SourceFormatter {
 
 		JIRAUtil.validateJIRASecurityKeywords(
 			commitMessages,
-			_getPropertyValues("jira.security.vulnerability.keywords"), 20);
+			_getPropertyValues("jira.security.vulnerability.keywords"));
 	}
 
 	private static final String _PROPERTIES_FILE_NAME =

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/SourceFormatterArgs.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/SourceFormatterArgs.java
@@ -64,7 +64,7 @@ public class SourceFormatterArgs {
 
 	public static final boolean SHOW_DEBUG_INFORMATION = false;
 
-	public static final boolean VALIDATE_COMMIT_MESSAGES = false;
+	public static final boolean VALIDATE_COMMIT_MESSAGES = true;
 
 	public void addRecentChangesFileNames(
 		Collection<String> fileNames, String baseDirName) {

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/JIRAUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/JIRAUtil.java
@@ -85,8 +85,7 @@ public class JIRAUtil {
 		for (String commitMessage : commitMessages) {
 			for (String keyword : keywords) {
 				Pattern pattern = Pattern.compile(
-					"\\W(" + keyword + "\\w*)(\\W|\\Z)",
-					Pattern.CASE_INSENSITIVE);
+					"\\b_*(" + keyword + ")_*\\b", Pattern.CASE_INSENSITIVE);
 
 				Matcher matcher = pattern.matcher(commitMessage);
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/JIRAUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/JIRAUtil.java
@@ -73,29 +73,6 @@ public class JIRAUtil {
 		}
 	}
 
-	public static void validateJIRASecurityKeywords(
-			List<String> commitMessages, List<String> keywords)
-		throws Exception {
-
-		for (String commitMessage : commitMessages) {
-			for (String keyword : keywords) {
-				Pattern pattern = Pattern.compile(
-					"\\b_*(" + keyword + ")_*\\b", Pattern.CASE_INSENSITIVE);
-
-				Matcher matcher = pattern.matcher(commitMessage);
-
-				if (matcher.find()) {
-					throw new Exception(
-						StringBundler.concat(
-							"The commit '", commitMessage,
-							"' contains the word '", keyword,
-							"', which could reveal potential security ",
-							"vulnerablities."));
-				}
-			}
-		}
-	}
-
 	public static void validateJIRATicketIds(
 			List<String> commitMessages, int maxNumberOfTickets)
 		throws Exception {

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/JIRAUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/JIRAUtil.java
@@ -89,7 +89,7 @@ public class JIRAUtil {
 						StringBundler.concat(
 							"The commit '", commitMessage,
 							"' contains the word '", keyword,
-							"' , which could reveal potential security ",
+							"', which could reveal potential security ",
 							"vulnerablities."));
 				}
 			}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/JIRAUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/JIRAUtil.java
@@ -27,10 +27,8 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
@@ -79,47 +77,12 @@ public class JIRAUtil {
 	}
 
 	public static void validateJIRASecurityKeywords(
-		List<String> commitMessages, List<String> keywords,
-		int maxNumberOfTickets) {
-
-		Map<String, Integer> responseCodeMap = new HashMap<>();
+		List<String> commitMessages, List<String> keywords) {
 
 		Set<String> violatingCommitMessages = new TreeSet<>();
 		Set<String> violatingWords = new TreeSet<>();
 
 		for (String commitMessage : commitMessages) {
-			if (responseCodeMap.size() == maxNumberOfTickets) {
-				return;
-			}
-
-			String jiraTicketId = _getJIRATicketId(commitMessage);
-
-			if (jiraTicketId == null) {
-				continue;
-			}
-
-			Integer jiraTicketResponseCode = responseCodeMap.get(jiraTicketId);
-
-			if (jiraTicketResponseCode == null) {
-				try {
-					jiraTicketResponseCode = _getJIRATicketResponseCode(
-						jiraTicketId);
-
-					responseCodeMap.put(jiraTicketId, jiraTicketResponseCode);
-				}
-				catch (IOException ioException) {
-					if (_log.isDebugEnabled()) {
-						_log.debug(ioException);
-					}
-
-					return;
-				}
-			}
-
-			if (jiraTicketResponseCode != HttpServletResponse.SC_UNAUTHORIZED) {
-				continue;
-			}
-
 			for (String keyword : keywords) {
 				Pattern pattern = Pattern.compile(
 					"\\W(" + keyword + "\\w*)(\\W|\\Z)",

--- a/portal-impl/build.xml
+++ b/portal-impl/build.xml
@@ -526,7 +526,6 @@ svn://svn.liferay.com/repos/public/alloy/trunk/sandbox/taglibs.
 							<then>
 								<property name="format.current.branch" value="true" />
 								<property name="source.formatter.message" value="Running SourceFormatter on added/modified files in the current branch (${current.branch.name}) only. Please run the following command to run SourceFormatter on all files:${line.separator}${line.separator}ant format-source-all" />
-								<property name="validate.commit.messages" value="true" />
 							</then>
 						</if>
 
@@ -619,7 +618,6 @@ svn://svn.liferay.com/repos/public/alloy/trunk/sandbox/taglibs.
 					<arg value="source.files=${source.files}" />
 					<arg value="source.formatter.properties=${source.formatter.properties}" />
 					<arg value="source.print.errors=${source.print.errors}" />
-					<arg value="validate.commit.messages=${validate.commit.messages}" />
 				</java>
 
 				<delete file="ServiceBuilder.temp" />

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -107,7 +107,7 @@
     # Input a list of comma delimited words that are not allowed to use in git
     # commit messages.
     #
-    vulnerability.keywords=\
+    git.commit.vulnerability.keywords=\
         authenticat,\
         csrf,\
         cve,\

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -104,6 +104,27 @@
         portal-kernel/test/unit/com/liferay/portal/kernel/security/SecureRandomUtilTest.java
 
     #
+    # Input a list of comma delimited words that are not allowed to use in git
+    # commit messages.
+    #
+    vulnerability.keywords=\
+        authenticat,\
+        csrf,\
+        cve,\
+        dangerous,\
+        deserialization,\
+        escap,\
+        forbidden,\
+        login,\
+        password,\
+        secret,\
+        secur,\
+        ssrf,\
+        trust,\
+        vulnerab,\
+        xss
+
+    #
     # Input a list of comma delimited objects in service.xml files that are
     # allowed to have unsorted finder-columns.
     #
@@ -164,23 +185,6 @@
         RELEASE,\
         SYNC,\
         TR
-
-    jira.security.vulnerability.keywords=\
-        authenticat,\
-        csrf,\
-        cve,\
-        dangerous,\
-        deserialization,\
-        escap,\
-        forbidden,\
-        login,\
-        password,\
-        secret,\
-        secur,\
-        ssrf,\
-        trust,\
-        vulnerab,\
-        xss
 
 ##
 ## Checkstyle Properties


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-166801

Fix:
1. No need to check response status of JIRA url when we check commit messages.
2. Always(run SF on PR, or run SF on local) check commit messages.