### PR TITLE
LPS-168892 Allow chaining for WebClient

### DIFF
--- a/modules/util/source-formatter/src/main/resources/checkstyle.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle.xml
@@ -258,7 +258,7 @@
 		</module>
 		<module name="com.liferay.source.formatter.checkstyle.check.ChainingCheck">
 			<property name="allowConcatChain" value="true" />
-			<property name="allowedClassNames" value="ActionSemantics,.*[Bb]uilder(s)?,Assertions,Awaitility,.*Consumer,CreationMenuBuilder,DSL.+FactoryUtil,EasyMock,Either,Filter,FormNavigatorEntryConfigurationRetriever,GenericUtil,InfoFieldSet,InfoForm,InfoFormValues,JSONUtil,List,MemberMatcher,Option,Optional,OSGi,Response,RestAssured,(Double|Int|Long)?Stream,.+Table,Try,Validation" />
+			<property name="allowedClassNames" value="ActionSemantics,.*[Bb]uilder(s)?,Assertions,Awaitility,.*Consumer,CreationMenuBuilder,DSL.+FactoryUtil,EasyMock,Either,Filter,FormNavigatorEntryConfigurationRetriever,GenericUtil,InfoFieldSet,InfoForm,InfoFormValues,JSONUtil,List,MemberMatcher,Option,Optional,OSGi,Response,RestAssured,(Double|Int|Long)?Stream,.+Table,Try,Validation,WebClient" />
 			<property name="allowedMethodNames" value="bind,builder,create,getKeywordsPredicate,newBuilder,put" />
 			<property name="allowedMockitoMethodNames" value="doAnswer,doCallRealMethod,doNothing,doReturn,doThrow,field,replace,stub,verify,verifyPrivate,when" />
 			<property name="allowedVariableTypeNames" value="^(?!String).+Builder(Impl)?,Column,CompletableFuture,.*Consumer,ContactsEngineClient,Dataset,Description,ExecuteActionRequest,(FormsEventDataset)?Filter,.*Function[0-9]*,HttpSecurity,InOrder,JSONArray,JSONObject,JsonPath,.*Mapper,NestedRepresentor.*,Optional,Predicate,RequestSpecification,Response,SoyContext,.+Step,(Double|Int|Long)?Stream,Try,UpdateFieldPropertyRequest,ValidatableResponse,WebTarget" />


### PR DESCRIPTION
https://github.com/liferay/liferay-portal/blob/e29a65ee4de80324d291b631de9bc76d8b7ae4f8/workspaces/sample-minimal-workspace/client-extensions/easy/src/main/java/com/liferay/sample/minimal/workspace/easy/EasyRestController.java#L129-L136

```
webClient.post(
).uri(
jsonObject.getString("transitionURL")
).bodyValue(
"{transitionName: \"approve\"}"
).header(
HttpHeaders.AUTHORIZATION, "Bearer " + jwt.getTokenValue()
).exchangeToMono(
```

