### PR TITLE
LPS-173386 Fix race condition and Windows-style path issue

### DIFF
--- a/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/client/AsahFaroBackendClientImpl.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/client/AsahFaroBackendClientImpl.java
@@ -380,26 +380,6 @@ public class AsahFaroBackendClientImpl implements AsahFaroBackendClient {
 		return uriVariables;
 	}
 
-	private String _invoke(Http.Options httpOptions) throws Exception {
-		String response = _http.URLtoString(httpOptions);
-
-		Http.Response httpResponse = httpOptions.getResponse();
-
-		if (httpResponse.getResponseCode() != HttpURLConnection.HTTP_OK) {
-			if (_log.isDebugEnabled()) {
-				_log.debug("Response code " + httpResponse.getResponseCode());
-			}
-
-			throw new NestableRuntimeException(
-				StringBundler.concat(
-					"Unexpected response status ",
-					httpResponse.getResponseCode(), " with response message: ",
-					response));
-		}
-
-		return response;
-	}
-
 	private MultivaluedMap<String, Object> _getUriVariables(
 		int cur, int delta, List<OrderByField> orderByFields,
 		String fieldNameContext) {
@@ -436,6 +416,26 @@ public class AsahFaroBackendClientImpl implements AsahFaroBackendClient {
 		uriVariables.put("sort", sort);
 
 		return uriVariables;
+	}
+
+	private String _invoke(Http.Options httpOptions) throws Exception {
+		String response = _http.URLtoString(httpOptions);
+
+		Http.Response httpResponse = httpOptions.getResponse();
+
+		if (httpResponse.getResponseCode() != HttpURLConnection.HTTP_OK) {
+			if (_log.isDebugEnabled()) {
+				_log.debug("Response code " + httpResponse.getResponseCode());
+			}
+
+			throw new NestableRuntimeException(
+				StringBundler.concat(
+					"Unexpected response status ",
+					httpResponse.getResponseCode(), " with response message: ",
+					response));
+		}
+
+		return response;
 	}
 
 	private String _patch(long companyId, String path, Object object)

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/XMLLog4jLoggersCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/XMLLog4jLoggersCheck.java
@@ -93,9 +93,11 @@ public class XMLLog4jLoggersCheck extends BaseFileCheck {
 	}
 
 	private synchronized List<String> _getSrcPaths() throws Exception {
-		if (!_srcPaths.isEmpty()) {
+		if (_srcPaths != null) {
 			return _srcPaths;
 		}
+
+		_srcPaths = new ArrayList<>();
 
 		File file = getPortalDir();
 
@@ -113,6 +115,6 @@ public class XMLLog4jLoggersCheck extends BaseFileCheck {
 		return _srcPaths;
 	}
 
-	private final List<String> _srcPaths = new ArrayList<>();
+	private List<String> _srcPaths;
 
 }

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/XMLLog4jLoggersCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/XMLLog4jLoggersCheck.java
@@ -49,11 +49,15 @@ public class XMLLog4jLoggersCheck extends BaseFileCheck {
 	private void _checkLoggers(String fileName, String content)
 		throws Exception {
 
+		List<String> srcPaths = _getSrcPaths();
+
+		if (srcPaths.isEmpty()) {
+			return;
+		}
+
 		Document document = SourceUtil.readXML(content);
 
 		Element rootElement = document.getRootElement();
-
-		List<String> srcPaths = _getSrcPaths();
 
 		for (Element loggersElement :
 				(List<Element>)rootElement.elements("Loggers")) {

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/XMLLog4jLoggersCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/XMLLog4jLoggersCheck.java
@@ -20,9 +20,8 @@ import com.liferay.source.formatter.check.util.SourceUtil;
 
 import java.io.File;
 
-import java.util.HashSet;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 import org.dom4j.Document;
 import org.dom4j.Element;
@@ -54,7 +53,7 @@ public class XMLLog4jLoggersCheck extends BaseFileCheck {
 
 		Element rootElement = document.getRootElement();
 
-		Set<String> srcPaths = _getSrcPaths();
+		List<String> srcPaths = _getSrcPaths();
 
 		for (Element loggersElement :
 				(List<Element>)rootElement.elements("Loggers")) {
@@ -71,7 +70,7 @@ public class XMLLog4jLoggersCheck extends BaseFileCheck {
 				String path = StringUtil.replace(
 					name, CharPool.PERIOD, CharPool.SLASH);
 
-				if (_srcPaths.contains(path)) {
+				if (srcPaths.contains(path)) {
 					continue;
 				}
 
@@ -93,7 +92,7 @@ public class XMLLog4jLoggersCheck extends BaseFileCheck {
 		}
 	}
 
-	private Set<String> _getSrcPaths() throws Exception {
+	private synchronized List<String> _getSrcPaths() throws Exception {
 		if (!_srcPaths.isEmpty()) {
 			return _srcPaths;
 		}
@@ -105,12 +104,15 @@ public class XMLLog4jLoggersCheck extends BaseFileCheck {
 			new String[] {"**/com/liferay/**/*.java"});
 
 		for (String fileName : fileNames) {
+			fileName = StringUtil.replace(
+				fileName, CharPool.BACK_SLASH, CharPool.SLASH);
+
 			_srcPaths.add(fileName.substring(fileName.indexOf("com/liferay/")));
 		}
 
 		return _srcPaths;
 	}
 
-	private final Set<String> _srcPaths = new HashSet<>();
+	private final List<String> _srcPaths = new ArrayList<>();
 
 }

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLImpl.java
@@ -160,8 +160,7 @@ public class DLImpl implements DL {
 
 			if (!folders.contains(rootFolder)) {
 				throw new InvalidFolderException(
-					InvalidFolderException.INVALID_ROOT_FOLDER,
-					rootFolderId);
+					InvalidFolderException.INVALID_ROOT_FOLDER, rootFolderId);
 			}
 
 			folders = ListUtil.subList(folders, 0, folders.indexOf(rootFolder));


### PR DESCRIPTION
Ticket: [LPS-173386](https://issues.liferay.com/browse/LPS-173386)

Hi @ling-alan-huang and @qz1010. I decided to make some changes with how the SF check deals with paths. Rather than convert the logger names to filepaths, I think we should convert the filepaths to class/package names.

Let me know if there is a better way.