### PR TITLE
LPS-181208 Refactor unit tests in SF

### DIFF
--- a/modules/util/source-formatter/source-formatter.properties
+++ b/modules/util/source-formatter/source-formatter.properties
@@ -9,7 +9,8 @@
         modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/JavaSourceProcessorTest.java
 
     checkstyle.ChainingCheck.allowedClassNames=\
-        Comparator
+        Comparator,\
+        SourceProcessorTestInput
 
     checkstyle.RedundantLogCheck.enabled=true
 

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/BNDSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/BNDSourceProcessorTest.java
@@ -31,26 +31,30 @@ public class BNDSourceProcessorTest extends BaseSourceProcessorTestCase {
 			"Deprecated apps that are not published on Marketplace should be " +
 				"moved to the archived folder");
 		test(
-			"FormatBndInstructions3/app.testbnd",
-			new String[] {
+			SourceProcessorTestParameters.create(
+				"FormatBndInstructions3/app.testbnd"
+			).addExpectedMessage(
 				"The 'Liferay-Releng-Restart-Required' can only be set to " +
-					"false if a POSHI tests exists",
+					"false if a POSHI tests exists"
+			).addExpectedMessage(
 				StringBundler.concat(
 					"The 'Liferay-Releng-Suite' can be blank or one of the ",
 					"following values 'collaboration, commerce, ",
 					"forms-and-workflow, foundation, static, web-experience'")
-			});
+			));
 	}
 
 	@Test
 	public void testFormatDefinitionKeys() throws Exception {
 		test("FormatDefinitionKeys1/common.testbnd");
 		test(
-			"FormatDefinitionKeys2/common.testbnd",
-			new String[] {
-				"Unknown key \"-fixupmessagess\"",
+			SourceProcessorTestParameters.create(
+				"FormatDefinitionKeys2/common.testbnd"
+			).addExpectedMessage(
+				"Unknown key \"-fixupmessagess\""
+			).addExpectedMessage(
 				"Unknown key \"Liferay-Portal-ServerInfo\""
-			});
+			));
 	}
 
 	@Test

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/JSONSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/JSONSourceProcessorTest.java
@@ -68,13 +68,15 @@ public class JSONSourceProcessorTest extends BaseSourceProcessorTestCase {
 	@Test
 	public void testJSONDeprecatedPackagesCheck() throws Exception {
 		test(
-			"JSONDeprecatedPackages/package.testjson",
-			new String[] {
+			SourceProcessorTestParameters.create(
+				"JSONDeprecatedPackages/package.testjson"
+			).addExpectedMessage(
 				"Do not use deprecated package " +
 					"'liferay-module-config-generator'",
-				"Do not use deprecated package 'metal-cli'"
-			},
-			new Integer[] {4, 5});
+				4
+			).addExpectedMessage(
+				"Do not use deprecated package 'metal-cli'", 5
+			));
 	}
 
 	@Test

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/JSPSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/JSPSourceProcessorTest.java
@@ -84,12 +84,13 @@ public class JSPSourceProcessorTest extends BaseSourceProcessorTestCase {
 	@Test
 	public void testIncorrectMethodCalls() throws Exception {
 		test(
-			"IncorrectMethodCalls.testjsp",
-			new String[] {
-				"Use type 'LiferayPortletResponse' to call 'getNamespace()'",
-				"Use type 'LiferayPortletResponse' to call 'getNamespace()'"
-			},
-			new Integer[] {21, 28});
+			SourceProcessorTestParameters.create(
+				"IncorrectMethodCalls.testjsp"
+			).addExpectedMessage(
+				"Use type 'LiferayPortletResponse' to call 'getNamespace()'", 21
+			).addExpectedMessage(
+				"Use type 'LiferayPortletResponse' to call 'getNamespace()'", 28
+			));
 	}
 
 	@Test
@@ -116,12 +117,15 @@ public class JSPSourceProcessorTest extends BaseSourceProcessorTestCase {
 	@Test
 	public void testMissingTaglibs() throws Exception {
 		test(
-			"MissingTaglibs.testjsp",
-			new String[] {
-				"Missing taglib for tag with prefix 'aui'",
-				"Missing taglib for tag with prefix 'liferay-portlet'",
+			SourceProcessorTestParameters.create(
+				"MissingTaglibs.testjsp"
+			).addExpectedMessage(
+				"Missing taglib for tag with prefix 'aui'"
+			).addExpectedMessage(
+				"Missing taglib for tag with prefix 'liferay-portlet'"
+			).addExpectedMessage(
 				"Missing taglib for tag with prefix 'liferay-ui'"
-			});
+			));
 	}
 
 	@Test

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/JavaSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/JavaSourceProcessorTest.java
@@ -36,31 +36,24 @@ public class JavaSourceProcessorTest extends BaseSourceProcessorTestCase {
 	@Test
 	public void testAssignmentsAndSetCallsOrder() throws Exception {
 		test(
-			"AssignmentsAndSetCallsOrder.testjava",
-			new String[] {
-				"The variable assignment for 'appDeployments' should come before the variable assignment for 'dataDefinitionId'",
-				"The variable assignment for 'settings' should come before the variable assignment for 'type'",
-				"The variable assignment for 'type' shoud come before the method calling 'setName'",
-				"The variable assignment for 'settings' should come before the variable assignment for 'type'",
-				"The method calling 'setCompany' should come before the method calling 'setName'"
-			},
-			new Integer[] {29, 33, 42, 48, 54});
+			SourceProcessorTestParameters.create("AssignmentsAndSetCallsOrder.testjava")
+				.addExpectedMessage("The variable assignment for 'appDeployments' should come before the variable assignment for 'dataDefinitionId'", 29)
+				.addExpectedMessage("The variable assignment for 'settings' should come before the variable assignment for 'type'", 33)
+				.addExpectedMessage("The variable assignment for 'type' shoud come before the method calling 'setName'", 42)
+				.addExpectedMessage("The variable assignment for 'settings' should come before the variable assignment for 'type'", 48)
+				.addExpectedMessage("The method calling 'setCompany' should come before the method calling 'setName'", 54)
+		);
 	}
 
 	@Test
 	public void testBuilder() throws Exception {
-		test(
-			"Builder.testjava",
-			new String[] {
-				"Include method call 'hashMap.put' (32) in 'HashMapBuilder' " +
-					"(28)",
-				"Inline variable definition 'company' (38) inside '" +
-					"HashMapBuilder' (40), possibly by using a lambda function",
-				"Null values are not allowed in 'HashMapBuilder'",
-				"Use 'HashMapBuilder' (52, 54)",
-				"Use 'HashMapBuilder' instead of new instance of 'HashMap'"
-			},
-			new Integer[] {28, 38, 47, 52, 58});
+		test(SourceProcessorTestParameters.create("Builder.testjava")
+				.addExpectedMessage("Include method call 'hashMap.put' (32) in 'HashMapBuilder' (28)", 28)
+				.addExpectedMessage("Inline variable definition 'company' (38) inside 'HashMapBuilder' (40), possibly by using a lambda function", 38)
+				.addExpectedMessage("Null values are not allowed in 'HashMapBuilder'", 47)
+				.addExpectedMessage("Use 'HashMapBuilder' (52, 54)", 52)
+				.addExpectedMessage("Use 'HashMapBuilder' instead of new instance of 'HashMap'", 58)
+		);
 	}
 
 	@Test
@@ -150,20 +143,17 @@ public class JavaSourceProcessorTest extends BaseSourceProcessorTestCase {
 
 	@Test
 	public void testExceptionVariableName() throws Exception {
-		test(
-			"ExceptionVariableName.testjava",
-			new String[] {
-				"Rename exception variable 'e' to 'configurationException'",
-				"Rename exception variable 'e' to 'configurationException'",
-				"Rename exception variable 're' to 'exception'",
-				"Rename exception variable 'ioe' to 'ioException1'",
-				"Rename exception variable 'oie' to 'ioException2'",
-				"Rename exception variable 'ioe1' to 'ioException1'",
-				"Rename exception variable 'ioe2' to 'ioException2'",
-				"Rename exception variable 'ioe1' to 'ioException'",
-				"Rename exception variable 'ioe2' to 'ioException'"
-			},
-			new Integer[] {37, 50, 61, 66, 70, 81, 85, 96, 102});
+		test(SourceProcessorTestParameters.create("ExceptionVariableName.testjava")
+				.addExpectedMessage("Rename exception variable 'e' to 'configurationException'", 37)
+				.addExpectedMessage("Rename exception variable 'e' to 'configurationException'", 50)
+				.addExpectedMessage("Rename exception variable 're' to 'exception'", 61)
+				.addExpectedMessage("Rename exception variable 'ioe' to 'ioException1'", 66)
+				.addExpectedMessage("Rename exception variable 'oie' to 'ioException2'", 70)
+				.addExpectedMessage("Rename exception variable 'ioe1' to 'ioException1'", 81)
+				.addExpectedMessage("Rename exception variable 'ioe2' to 'ioException2'", 85)
+				.addExpectedMessage("Rename exception variable 'ioe1' to 'ioException'", 96)
+				.addExpectedMessage("Rename exception variable 'ioe2' to 'ioException'", 102)
+		);
 	}
 
 	@Test
@@ -230,12 +220,11 @@ public class JavaSourceProcessorTest extends BaseSourceProcessorTestCase {
 	public void testIncorrectImports() throws Exception {
 		test("IncorrectImports1.testjava");
 		test(
-			"IncorrectImports2.testjava",
-			new String[] {
-				"Illegal import: edu.emory.mathcs.backport.java",
-				"Illegal import: jodd.util.StringPool",
-				"Use ProxyUtil instead of java.lang.reflect.Proxy"
-			});
+			SourceProcessorTestParameters.create("IncorrectImports2.testjava")
+				.addExpectedMessage("Illegal import: edu.emory.mathcs.backport.java")
+				.addExpectedMessage("Illegal import: jodd.util.StringPool")
+				.addExpectedMessage("Use ProxyUtil instead of java.lang.reflect.Proxy")
+			);
 	}
 
 	@Test
@@ -246,71 +235,54 @@ public class JavaSourceProcessorTest extends BaseSourceProcessorTestCase {
 	@Test
 	public void testIncorrectOperatorOrder() throws Exception {
 		test(
-			"IncorrectOperatorOrder.testjava",
-			new String[] {
-				"'3' should be on the right hand side of the operator",
-				"'+3' should be on the right hand side of the operator",
-				"'-3' should be on the right hand side of the operator",
-				"'3' should be on the right hand side of the operator",
-				"'+3' should be on the right hand side of the operator",
-				"'-3' should be on the right hand side of the operator",
-				"'3' should be on the right hand side of the operator",
-				"'+3' should be on the right hand side of the operator",
-				"'-3' should be on the right hand side of the operator",
-				"'3' should be on the right hand side of the operator",
-				"'+3' should be on the right hand side of the operator",
-				"'-3' should be on the right hand side of the operator",
-				"'3' should be on the right hand side of the operator",
-				"'+3' should be on the right hand side of the operator",
-				"'-3' should be on the right hand side of the operator",
-				"'3' should be on the right hand side of the operator",
-				"'+3' should be on the right hand side of the operator",
-				"'-3' should be on the right hand side of the operator"
-			},
-			new Integer[] {
-				53, 57, 61, 97, 101, 105, 141, 145, 149, 185, 189, 193, 229,
-				233, 237, 273, 277, 281
-			});
+			SourceProcessorTestParameters.create("IncorrectOperatorOrder.testjava")
+				.addExpectedMessage("'3' should be on the right hand side of the operator", 53)
+				.addExpectedMessage("'+3' should be on the right hand side of the operator", 57)
+				.addExpectedMessage("'-3' should be on the right hand side of the operator", 61)
+				.addExpectedMessage("'3' should be on the right hand side of the operator", 97)
+				.addExpectedMessage("'+3' should be on the right hand side of the operator", 101)
+				.addExpectedMessage("'-3' should be on the right hand side of the operator", 105)
+				.addExpectedMessage("'3' should be on the right hand side of the operator", 141)
+				.addExpectedMessage("'+3' should be on the right hand side of the operator", 145)
+				.addExpectedMessage("'-3' should be on the right hand side of the operator", 149)
+				.addExpectedMessage("'3' should be on the right hand side of the operator", 185)
+				.addExpectedMessage("'+3' should be on the right hand side of the operator", 189)
+				.addExpectedMessage("'-3' should be on the right hand side of the operator", 193)
+				.addExpectedMessage("'3' should be on the right hand side of the operator", 229)
+				.addExpectedMessage("'+3' should be on the right hand side of the operator", 233)
+				.addExpectedMessage("'-3' should be on the right hand side of the operator", 237)
+				.addExpectedMessage("'3' should be on the right hand side of the operator", 273)
+				.addExpectedMessage("'+3' should be on the right hand side of the operator", 277)
+				.addExpectedMessage("'-3' should be on the right hand side of the operator", 281)
+			);
 		}
 
 	@Test
 	public void testIncorrectParameterNames() throws Exception {
 		test(
-			"IncorrectParameterNames.testjava",
-			new String[] {
-				"Parameter 'StringMap' must match pattern " +
-					"'^[a-z][_a-zA-Z0-9]*$'",
-				"Parameter 'TestString' must match pattern " +
-					"'^[a-z][_a-zA-Z0-9]*$'"
-			},
-			new Integer[] {24, 28});
+			SourceProcessorTestParameters.create("IncorrectParameterNames.testjava")
+				.addExpectedMessage("Parameter 'StringMap' must match pattern '^[a-z][_a-zA-Z0-9]*$'", 24)
+				.addExpectedMessage("Parameter 'TestString' must match pattern '^[a-z][_a-zA-Z0-9]*$'", 28)
+			);
 	}
 
 	@Test
 	public void testIncorrectVariableNames() throws Exception {
 		test(
-			"IncorrectVariableNames1.testjava",
-			new String[] {
-				"public constant '_TEST_1' of type 'int' must match pattern " +
-					"'^[A-Z0-9][_A-Z0-9]*$'",
-				"Protected or public non-static field '_test2' must match " +
-					"pattern '^[a-z0-9][_a-zA-Z0-9]*$'"
-			},
-			new Integer[] {22, 28});
+			SourceProcessorTestParameters.create("IncorrectVariableNames1.testjava")
+				.addExpectedMessage("public constant '_TEST_1' of type 'int' must match pattern '^[A-Z0-9][_A-Z0-9]*$'", 22)
+				.addExpectedMessage("Protected or public non-static field '_test2' must match pattern '^[a-z0-9][_a-zA-Z0-9]*$'", 28)
+			);
 		test(
 			"IncorrectVariableNames2.testjava",
 			"private constant 'STRING_1' of type 'String' must match pattern " +
 				"'^_[A-Z0-9][_A-Z0-9]*$'",
 			26);
 		test(
-			"IncorrectVariableNames3.testjava",
-			new String[] {
-				"Local non-final variable 'TestMapWithARatherLongName' must " +
-					"match pattern '^[a-z0-9][_a-zA-Z0-9]*$'",
-				"Local non-final variable 'TestString' must match pattern " +
-					"'^[a-z0-9][_a-zA-Z0-9]*$'"
-			},
-			new Integer[] {26, 29});
+			SourceProcessorTestParameters.create("IncorrectVariableNames3.testjava")
+				.addExpectedMessage("Local non-final variable 'TestMapWithARatherLongName' must match pattern '^[a-z0-9][_a-zA-Z0-9]*$'", 26)
+				.addExpectedMessage("Local non-final variable 'TestString' must match pattern '^[a-z0-9][_a-zA-Z0-9]*$'", 29)
+			);
 	}
 
 	@Test
@@ -320,13 +292,10 @@ public class JavaSourceProcessorTest extends BaseSourceProcessorTestCase {
 
 	@Test
 	public void testInefficientStringMethods() throws Exception {
-		test(
-			"InefficientStringMethods.testjava",
-			new String[] {
-				"Use StringUtil.equalsIgnoreCase", "Use StringUtil.toLowerCase",
-				"Use StringUtil.toUpperCase"
-			},
-			new Integer[] {26, 30, 31});
+		test(SourceProcessorTestParameters.create("InefficientStringMethods.testjava")
+			.addExpectedMessage("Use StringUtil.equalsIgnoreCase",  26)
+			.addExpectedMessage("Use StringUtil.toLowerCase", 30)
+				.addExpectedMessage("Use StringUtil.toUpperCase", 31));
 	}
 
 	@Test
@@ -351,14 +320,12 @@ public class JavaSourceProcessorTest extends BaseSourceProcessorTestCase {
 
 	@Test
 	public void testToJSONStringMethodCalls() throws Exception {
-		test("ToJSONStringMethodCalls.testjava",
-			new String[] {
-				"Use 'toString' instead of 'toJSONString'",
-				"Use 'toString' instead of 'toJSONString'",
-				"Use 'toString' instead of 'toJSONString'",
-				"Use 'toString' instead of 'toJSONString'"
-			},
-			new Integer[] {30, 39, 43, 67});
+		test(SourceProcessorTestParameters.create("ToJSONStringMethodCalls.testjava")
+				.addExpectedMessage("Use 'toString' instead of 'toJSONString'", 30)
+				.addExpectedMessage("Use 'toString' instead of 'toJSONString'", 39)
+				.addExpectedMessage("Use 'toString' instead of 'toJSONString'", 43)
+				.addExpectedMessage("Use 'toString' instead of 'toJSONString'", 67)
+		);
 	}
 
 	@Test
@@ -371,13 +338,14 @@ public class JavaSourceProcessorTest extends BaseSourceProcessorTestCase {
 	@Test
 	public void testLogLevels() throws Exception {
 		test(
-			"Levels.testjava",
-			new String[] {
-				"Do not use _log.isErrorEnabled()", "Use _log.isDebugEnabled()",
-				"Use _log.isDebugEnabled()", "Use _log.isInfoEnabled()",
-				"Use _log.isTraceEnabled()", "Use _log.isWarnEnabled()"
-			},
-			new Integer[] {27, 36, 41, 53, 58, 68});
+			SourceProcessorTestParameters.create("Levels.testjava")
+				.addExpectedMessage("Do not use _log.isErrorEnabled()", 27)
+				.addExpectedMessage("Use _log.isDebugEnabled()", 36)
+				.addExpectedMessage("Use _log.isDebugEnabled()", 41)
+				.addExpectedMessage("Use _log.isInfoEnabled()", 53)
+				.addExpectedMessage("Use _log.isTraceEnabled()", 58)
+				.addExpectedMessage("Use _log.isWarnEnabled()", 68)
+			);
 	}
 
 	@Test
@@ -402,14 +370,10 @@ public class JavaSourceProcessorTest extends BaseSourceProcessorTestCase {
 
 	@Test
 	public void testMissingEmptyLinesAfterMethodCalls() throws Exception {
-		test(
-			"MissingEmptyLinesAfterMethodCalls.testjava",
-			new String[] {
-				"There should be an empty line after 'registry.register'",
-				"There should be an empty line after 'registry.register'",
-				"There should be an empty line after 'registry.register'"
-			},
-			new Integer[] {23, 24, 34});
+		test(SourceProcessorTestParameters.create("MissingEmptyLinesAfterMethodCalls.testjava")
+			.addExpectedMessage("There should be an empty line after 'registry.register'", 23)
+			.addExpectedMessage("There should be an empty line after 'registry.register'", 24)
+			.addExpectedMessage("There should be an empty line after 'registry.register'", 34));
 	}
 
 	@Test
@@ -430,33 +394,27 @@ public class JavaSourceProcessorTest extends BaseSourceProcessorTestCase {
 
 	@Test
 	public void testMissingDiamondOperator() throws Exception {
-		test("MissingDiamondOperator.testjava",
-			new String[] {
-				"Missing diamond operator '<>' for type 'ArrayList'",
-				"Missing generic types '<String, String>' for type 'ArrayList'",
-				"Missing diamond operator '<>' for type 'ConcurrentHashMap'",
-				"Missing diamond operator '<>' for type " +
-					"'ConcurrentSkipListMap'",
-				"Missing diamond operator '<>' for type " +
-					"'ConcurrentSkipListSet'",
-				"Missing diamond operator '<>' for type 'CopyOnWriteArraySet'",
-				"Missing generic types '<Position, String>' for type 'EnumMap'",
-				"Missing diamond operator '<>' for type 'HashMap'",
-				"Missing diamond operator '<>' for type 'HashSet'",
-				"Missing diamond operator '<>' for type 'Hashtable'",
-				"Missing diamond operator '<>' for type 'IdentityHashMap'",
-				"Missing diamond operator '<>' for type 'LinkedHashMap'",
-				"Missing diamond operator '<>' for type 'LinkedHashSet'",
-				"Missing diamond operator '<>' for type 'LinkedList'",
-				"Missing diamond operator '<>' for type 'Stack'",
-				"Missing diamond operator '<>' for type 'TreeMap'",
-				"Missing diamond operator '<>' for type 'TreeSet'",
-				"Missing diamond operator '<>' for type 'Vector'",
-			},
-			new Integer[] {
-				45, 47, 53, 55, 57, 59, 61, 68, 70, 72, 74, 77, 79, 81, 83, 85,
-				87, 89
-			});
+		test(
+			SourceProcessorTestParameters.create("MissingDiamondOperator.testjava")
+				.addExpectedMessage("Missing diamond operator '<>' for type 'ArrayList'", 45)
+				.addExpectedMessage("Missing generic types '<String, String>' for type 'ArrayList'", 47)
+				.addExpectedMessage("Missing diamond operator '<>' for type 'ConcurrentHashMap'", 53)
+				.addExpectedMessage("Missing diamond operator '<>' for type 'ConcurrentSkipListMap'", 55)
+				.addExpectedMessage("Missing diamond operator '<>' for type 'ConcurrentSkipListSet'", 57)
+				.addExpectedMessage("Missing diamond operator '<>' for type 'CopyOnWriteArraySet'", 59)
+				.addExpectedMessage("Missing generic types '<Position, String>' for type 'EnumMap'", 61)
+				.addExpectedMessage("Missing diamond operator '<>' for type 'HashMap'", 68)
+				.addExpectedMessage("Missing diamond operator '<>' for type 'HashSet'", 70)
+				.addExpectedMessage("Missing diamond operator '<>' for type 'Hashtable'", 72)
+				.addExpectedMessage("Missing diamond operator '<>' for type 'IdentityHashMap'", 74)
+				.addExpectedMessage("Missing diamond operator '<>' for type 'LinkedHashMap'", 77)
+				.addExpectedMessage("Missing diamond operator '<>' for type 'LinkedHashSet'", 79)
+				.addExpectedMessage("Missing diamond operator '<>' for type 'LinkedList'", 81)
+				.addExpectedMessage("Missing diamond operator '<>' for type 'Stack'", 83)
+				.addExpectedMessage("Missing diamond operator '<>' for type 'TreeMap'", 85)
+				.addExpectedMessage("Missing diamond operator '<>' for type 'TreeSet'", 87)
+				.addExpectedMessage("Missing diamond operator '<>' for type 'Vector'", 89)
+			);
 	}
 
 	@Test
@@ -479,26 +437,19 @@ public class JavaSourceProcessorTest extends BaseSourceProcessorTestCase {
 	@Test
 	public void testMoveUpgradeSteps() throws Exception {
 		test(
-			"MoveUpgradeSteps.testjava",
-			new String[] {
-				"Move 'alterTableAddColumn' call inside 'getPreUpgradeSteps' " +
-					"method",
-				"Move 'alterTableAddColumn' call inside " +
-					"'getPostUpgradeSteps' method"
-			},
-			new Integer[] {26, 30});
+			SourceProcessorTestParameters.create("MoveUpgradeSteps.testjava")
+				.addExpectedMessage("Move 'alterTableAddColumn' call inside 'getPreUpgradeSteps' method", 26)
+				.addExpectedMessage("Move 'alterTableAddColumn' call inside 'getPostUpgradeSteps' method", 30)
+			);
 	}
 
 	@Test
 	public void testNullAssertionInIfStatement() throws Exception {
-		test(
-			"NullAssertionInIfStatement.testjava",
-			new String[] {
-					"Null check for variable 'list' should always be first in if-statement",
-					"Null check for variable 'list' should always be first in if-statement",
-					"Null check for variable 'nameList1' should always be first in if-statement"
-				},
-				new Integer[] {25, 33, 46});
+		test(SourceProcessorTestParameters.create("NullAssertionInIfStatement.testjava")
+				.addExpectedMessage("Null check for variable 'list' should always be first in if-statement", 25)
+				.addExpectedMessage("Null check for variable 'list' should always be first in if-statement", 33)
+			.addExpectedMessage("Null check for variable 'nameList1' should always be first in if-statement", 46)
+		);
 	}
 
 	@Test
@@ -565,14 +516,12 @@ public class JavaSourceProcessorTest extends BaseSourceProcessorTestCase {
 	@Test
 	public void testSingleStatementClause() throws Exception {
 		test(
-			"SingleStatementClause.testjava",
-			new String[] {
-				"Use braces around if-statement clause",
-				"Use braces around while-statement clause",
-				"Use braces around for-statement clause",
-				"Use braces around if-statement clause"
-			},
-			new Integer[] {23, 28, 31, 34});
+			SourceProcessorTestParameters.create("SingleStatementClause.testjava")
+				.addExpectedMessage("Use braces around if-statement clause", 23)
+				.addExpectedMessage("Use braces around while-statement clause", 28)
+				.addExpectedMessage("Use braces around for-statement clause", 31)
+				.addExpectedMessage("Use braces around if-statement clause", 34)
+		);
 	}
 
 	@Test
@@ -582,13 +531,9 @@ public class JavaSourceProcessorTest extends BaseSourceProcessorTestCase {
 
 	@Test
 	public void testSizeIsZeroCheck() throws Exception {
-		test(
-			"SizeIsZero.testjava",
-			new String[] {
-				"Use method '_testList.isEmpty()' instead",
-				"Use method 'myList.isEmpty()' instead",
-			},
-			new Integer[] {28, 33});
+		test(SourceProcessorTestParameters.create("SizeIsZero.testjava")
+			.addExpectedMessage("Use method '_testList.isEmpty()' instead", 28)
+				.addExpectedMessage("Use method 'myList.isEmpty()' instead", 33));
 	}
 
 	@Test
@@ -661,15 +606,13 @@ public class JavaSourceProcessorTest extends BaseSourceProcessorTestCase {
 	@Test
 	public void testUnnecessaryMethodCalls() throws Exception {
 		test(
-			"UnnecessaryMethodCalls.testjava",
-			new String[] {
-				"Use 'webCachePool' instead of calling method '_getWebCachePool'",
-				"Use 'webCachePool' instead of calling method '_getWebCachePool'",
-				"Use 'this.name' instead of calling method '_getName'",
-				"Use 'webCachePool' instead of calling method '_getWebCachePool'",
-				"Use 'webCachePool_1' instead of calling method 'getWebCachePool'"
-			},
-			new Integer[] {35, 43, 47, 53, 79});
+			SourceProcessorTestParameters.create("UnnecessaryMethodCalls.testjava")
+				.addExpectedMessage("Use 'webCachePool' instead of calling method '_getWebCachePool'", 35)
+				.addExpectedMessage("Use 'webCachePool' instead of calling method '_getWebCachePool'", 43)
+				.addExpectedMessage("Use 'this.name' instead of calling method '_getName'", 47)
+				.addExpectedMessage("Use 'webCachePool' instead of calling method '_getWebCachePool'", 53)
+				.addExpectedMessage("Use 'webCachePool_1' instead of calling method 'getWebCachePool'", 79)
+			);
 	}
 
 	@Test
@@ -690,12 +633,10 @@ public class JavaSourceProcessorTest extends BaseSourceProcessorTestCase {
 	@Test
 	public void testUnusedMethods() throws Exception {
 		test(
-			"UnusedMethods.testjava",
-			new String[] {
-				"Method '_getInteger' is unused",
-				"Method '_getString' is unused"
-			},
-			new Integer[] {33, 41});
+			SourceProcessorTestParameters.create("UnusedMethods.testjava")
+				.addExpectedMessage("Method '_getInteger' is unused", 33)
+				.addExpectedMessage("Method '_getString' is unused", 41)
+			);
 	}
 
 	@Test
@@ -706,12 +647,11 @@ public class JavaSourceProcessorTest extends BaseSourceProcessorTestCase {
 	@Test
 	public void testUnusedVariable() throws Exception {
 		test(
-			"UnusedVariable.testjava",
-			new String[] {
-				"Variable 'matcher' is unused", "Variable 'hello' is unused",
-				"Variable '_s' is unused"
-			},
-			new Integer[] {26, 29, 41});
+			SourceProcessorTestParameters.create("UnusedVariable.testjava")
+				.addExpectedMessage("Variable 'matcher' is unused", 26)
+				.addExpectedMessage("Variable 'hello' is unused", 29)
+				.addExpectedMessage("Variable '_s' is unused", 41)
+			);
 	}
 
 	@Test

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/PoshiSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/PoshiSourceProcessorTest.java
@@ -39,13 +39,15 @@ public class PoshiSourceProcessorTest extends BaseSourceProcessorTestCase {
 	@Test
 	public void testPoshiPauseUsage() throws Exception {
 		test(
-			"PoshiPauseUsage.testmacro",
-			new String[] {
-				"Missing a comment before using 'Pause'",
+			SourceProcessorTestParameters.create(
+				"PoshiPauseUsage.testmacro"
+			).addExpectedMessage(
+				"Missing a comment before using 'Pause'", 6
+			).addExpectedMessage(
 				"Missing a required JIRA project in comment before using " +
-					"'Pause'"
-			},
-			new Integer[] {6, 10});
+					"'Pause'",
+				10
+			));
 	}
 
 	@Test

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/SourceProcessorTestParameters.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/SourceProcessorTestParameters.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.source.formatter.processor;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author Kevin Lee
+ */
+public class SourceProcessorTestParameters {
+
+	public static SourceProcessorTestParameters create(String fileName) {
+		return new SourceProcessorTestParameters(fileName);
+	}
+
+	public SourceProcessorTestParameters addDependentFileName(
+		String dependentFileName) {
+
+		_dependentFileNames.add(dependentFileName);
+
+		return this;
+	}
+
+	public SourceProcessorTestParameters addExpectedMessage(String message) {
+		return addExpectedMessage(message, -1);
+	}
+
+	public SourceProcessorTestParameters addExpectedMessage(
+		String message, int lineNumber) {
+
+		_expectedMessages.add(message);
+		_lineNumbers.add(lineNumber);
+
+		return this;
+	}
+
+	public Set<String> getDependentFileNames() {
+		return _dependentFileNames;
+	}
+
+	public String getExpectedFileName() {
+		return _expectedFileName;
+	}
+
+	public List<String> getExpectedMessages() {
+		return _expectedMessages;
+	}
+
+	public String getFileName() {
+		return _fileName;
+	}
+
+	public List<Integer> getLineNumbers() {
+		return _lineNumbers;
+	}
+
+	public SourceProcessorTestParameters setExpectedFileName(
+		String expectedFileName) {
+
+		_expectedFileName = expectedFileName;
+
+		return this;
+	}
+
+	private SourceProcessorTestParameters(String fileName) {
+		_fileName = fileName;
+	}
+
+	private final Set<String> _dependentFileNames = new HashSet<>();
+	private String _expectedFileName;
+	private final List<String> _expectedMessages = new ArrayList<>();
+	private final String _fileName;
+	private final List<Integer> _lineNumbers = new ArrayList<>();
+
+}

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/TLDSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/TLDSourceProcessorTest.java
@@ -29,12 +29,13 @@ public class TLDSourceProcessorTest extends BaseSourceProcessorTestCase {
 	@Test
 	public void testMissingCDATA() throws Exception {
 		test(
-			"MissingCDATA.testtld",
-			new String[] {
-				"Use CDATA to warp each '<code>' in the description",
-				"Missing CDATA after 'replaced by' in the description"
-			},
-			new Integer[] {14, 19});
+			SourceProcessorTestParameters.create(
+				"MissingCDATA.testtld"
+			).addExpectedMessage(
+				"Use CDATA to warp each '<code>' in the description", 14
+			).addExpectedMessage(
+				"Missing CDATA after 'replaced by' in the description", 19
+			));
 	}
 
 	@Test

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/UpgradeSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/UpgradeSourceProcessorTest.java
@@ -46,18 +46,21 @@ public class UpgradeSourceProcessorTest extends BaseSourceProcessorTestCase {
 	@Test
 	public void testUpgradeGradleIncludeResourceCheck() throws Exception {
 		test(
-			"upgrade/upgrade-include-resource-check/build.testgradle",
-			new String[0],
-			new String[] {
+			SourceProcessorTestParameters.create(
+				"upgrade/upgrade-include-resource-check/build.testgradle"
+			).addDependentFileName(
 				"upgrade/upgrade-include-resource-check/bnd.testbnd"
-			});
+			));
 	}
 
 	@Test
 	public void testUpgradeVelocityCommentMigrationCheck() throws Exception {
-		testMigration(
-			"upgrade/UpgradeVelocityCommentMigrationCheck.testvm",
-			"upgrade/migrated/UpgradeVelocityCommentMigrationCheck.testftl");
+		test(
+			SourceProcessorTestParameters.create(
+				"upgrade/UpgradeVelocityCommentMigrationCheck.testvm"
+			).setExpectedFileName(
+				"upgrade/migrated/UpgradeVelocityCommentMigrationCheck.testftl"
+			));
 	}
 
 	@Test


### PR DESCRIPTION
Hi @ling-alan-huang,

I created this pull request to refactor unit tests in SF. The method overrides were getting confusing and the number of method parameters was getting too high. I decided to encapsulate all the test parameters into a class. Now, you have to create a `SourceFormatterTestInput` object for complicated test inputs. This approach should be extensible when more testing parameters need to be added.

I preserved the following methods:
- `test(String fileName)`
- `test(String fileName, String expectedMessage)`
- `test(String fileName, String expectedMessage, int lineNumber)`

Let me know your thoughts.