### PR TITLE
LPS-182623 `SourceProcessor` is not available in `JavaTermCheck` check

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BaseJavaTermCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BaseJavaTermCheck.java
@@ -23,6 +23,7 @@ import com.liferay.source.formatter.parser.JavaMethod;
 import com.liferay.source.formatter.parser.JavaStaticBlock;
 import com.liferay.source.formatter.parser.JavaTerm;
 import com.liferay.source.formatter.parser.JavaVariable;
+import com.liferay.source.formatter.processor.SourceProcessor;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,11 +38,13 @@ public abstract class BaseJavaTermCheck
 
 	@Override
 	public String process(
-			String fileName, String absolutePath, JavaClass javaClass,
-			String content)
+			SourceProcessor sourceProcessor, String fileName,
+			String absolutePath, JavaClass javaClass, String content)
 		throws Exception {
 
 		clearSourceFormatterMessages(fileName);
+
+		setSourceProcessor(sourceProcessor);
 
 		return _walkJavaClass(
 			fileName, absolutePath, javaClass, content, content);

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaTermCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaTermCheck.java
@@ -15,6 +15,7 @@
 package com.liferay.source.formatter.check;
 
 import com.liferay.source.formatter.parser.JavaClass;
+import com.liferay.source.formatter.processor.SourceProcessor;
 
 /**
  * @author Hugo Huijser
@@ -22,8 +23,8 @@ import com.liferay.source.formatter.parser.JavaClass;
 public interface JavaTermCheck extends SourceCheck {
 
 	public String process(
-			String fileName, String absolutePath, JavaClass javaClass,
-			String content)
+			SourceProcessor sourceProcessor, String fileName,
+			String absolutePath, JavaClass javaClass, String content)
 		throws Exception;
 
 }

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/util/SourceChecksUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/util/SourceChecksUtil.java
@@ -155,8 +155,9 @@ public class SourceChecksUtil {
 				}
 
 				sourceChecksResult = _processJavaTermCheck(
-					sourceChecksResult, (JavaTermCheck)sourceCheck, javaClass,
-					anonymousClasses, fileName, absolutePath);
+					sourceProcessor, sourceChecksResult,
+					(JavaTermCheck)sourceCheck, javaClass, anonymousClasses,
+					fileName, absolutePath);
 			}
 
 			sourceChecksResult.setMostRecentProcessedSourceCheck(sourceCheck);
@@ -391,6 +392,7 @@ public class SourceChecksUtil {
 	}
 
 	private static SourceChecksResult _processJavaTermCheck(
+			SourceProcessor sourceProcessor,
 			SourceChecksResult sourceChecksResult, JavaTermCheck javaTermCheck,
 			JavaClass javaClass, List<JavaClass> anonymousClasses,
 			String fileName, String absolutePath)
@@ -398,7 +400,7 @@ public class SourceChecksUtil {
 
 		sourceChecksResult.setContent(
 			javaTermCheck.process(
-				fileName, absolutePath, javaClass,
+				sourceProcessor, fileName, absolutePath, javaClass,
 				sourceChecksResult.getContent()));
 
 		for (SourceFormatterMessage sourceFormatterMessage :
@@ -411,7 +413,7 @@ public class SourceChecksUtil {
 		for (JavaClass anonymousClass : anonymousClasses) {
 			sourceChecksResult.setContent(
 				javaTermCheck.process(
-					fileName, absolutePath, anonymousClass,
+					sourceProcessor, fileName, absolutePath, anonymousClass,
 					sourceChecksResult.getContent()));
 
 			for (SourceFormatterMessage sourceFormatterMessage :


### PR DESCRIPTION
__Ticket:__ <https://issues.liferay.com/browse/LPS-182623>

This pull request makes it so that `JavaTermCheck` can access their respective `SourceProcessor` objects. At the moment, calling `JavaTermCheck.getSourceProcessor()` returns a `null` value.