### PR TITLE
LPS-175368 Only enable on master for now

### DIFF
--- a/modules/util/source-formatter/source-formatter.properties
+++ b/modules/util/source-formatter/source-formatter.properties
@@ -22,6 +22,8 @@
 
     source.check.JavaExceptionCheck.enabled=false
 
+    source.check.JavaGetFeatureFlagCheck.enabled=true
+
     source.check.JavaNewProblemInstantiationParametersCheck.enabled=true
 
     source.check.JavaReferenceAnnotationsCheck.checkReferenceMethod=true

--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -683,6 +683,7 @@
 		<check name="JavaGetFeatureFlagCheck">
 			<category name="Bug Prevention" />
 			<description name="Checks that `FeatureFlagManagerUtil.isEnabled` should be used (instead of `PropsUtil.get` in `GetterUtil.getBoolean`)." />
+			<property name="enabled" value="false" />
 		</check>
 		<check name="JavaHelperUtilCheck">
 			<category name="Naming Conventions" />

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -610,6 +610,8 @@
 
     source.check.JavaFinderCacheCheck.enabled=false
 
+    source.check.JavaGetFeatureFlagCheck.enabled=true
+
     source.check.JavaIgnoreAnnotationCheck.classNamesBlacklist=\
         com.liferay.portal.log.assertor.PortalLogAssertorTest
 


### PR DESCRIPTION
This PR updates `JavaGetFeatureFlagCheck` so that it is only enabled on `master`. At the moment, `FeatureFlagManagerUtil` is not available in `7.x` branches, so this check should not enforced on the `7.x` .branches. The commits in this PR can be reverted in the future if [LPS-168928](https://issues.liferay.com/browse/LPS-168928) is backported to `7.3.x`.