### PR TITLE
LPS-186213 Source Formatter does not recognize feature flags in batch JSON files

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/SourceFormatter.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/SourceFormatter.java
@@ -1147,7 +1147,8 @@ public class SourceFormatter {
 				(line.contains("feature.flag") ||
 				 line.contains("FeatureFlagManagerUtil.isEnabled(") ||
 				 line.contains("Liferay-Site-Initializer-Feature-Flag:") ||
-				 line.contains("Liferay.FeatureFlags['"))) {
+				 line.contains("Liferay.FeatureFlags['") ||
+				 line.contains("\"featureFlag\": \""))) {
 
 				return true;
 			}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/PropertiesFeatureFlagsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/PropertiesFeatureFlagsCheck.java
@@ -62,8 +62,8 @@ public class PropertiesFeatureFlagsCheck extends BaseFileCheck {
 		List<String> fileNames = SourceFormatterUtil.filterFileNames(
 			_allFileNames, new String[] {"**/test/**"},
 			new String[] {
-				"**/bnd.bnd", "**/*.java", "**/*.js", "**/*.jsp", "**/*.jspf",
-				"**/*.jsx", "**/*.ts", "**/*.tsx"
+				"**/bnd.bnd", "**/*.java", "**/*.js", "**/*.json", "**/*.jsp",
+				"**/*.jspf", "**/*.jsx", "**/*.ts", "**/*.tsx"
 			},
 			getSourceFormatterExcludes(), true);
 
@@ -88,6 +88,10 @@ public class PropertiesFeatureFlagsCheck extends BaseFileCheck {
 				featureFlags.addAll(
 					_getFeatureFlags(fileContent, _featureFlagPattern1));
 				featureFlags.addAll(_getFeatureFlags(fileContent));
+			}
+			else if (fileName.endsWith(".json")) {
+				featureFlags.addAll(
+					_getFeatureFlags(fileContent, _featureFlagPattern4));
 			}
 			else {
 				featureFlags.addAll(
@@ -200,6 +204,8 @@ public class PropertiesFeatureFlagsCheck extends BaseFileCheck {
 		"FeatureFlagManagerUtil\\.isEnabled\\(");
 	private static final Pattern _featureFlagPattern3 = Pattern.compile(
 		"Liferay\\.FeatureFlags\\['(.+?)'\\]");
+	private static final Pattern _featureFlagPattern4 = Pattern.compile(
+		"\"featureFlag\": \"(.+?)\",?");
 	private static final Pattern _featureFlagsPattern = Pattern.compile(
 		"(\n|\\A)##\n## Feature Flag\n##(\n\n[\\s\\S]*?)(?=(\n\n##|\\Z))");
 


### PR DESCRIPTION
This is an update for [LPS-186213](https://issues.liferay.com/browse/LPS-186213).

@ling-alan-huang this will detect feature flags in JSON files under this structure:
```json
{
    "featureFlag": "LPS-99999"
}
```
and with a comma:
```json
{
    "featureFlag": "LPS-99999",
    "otherKey": "otherValue"
}
```
This is intended to support `batch` declaration files. See this Slack thread: https://liferay.slack.com/archives/C1SJ64S9X/p1685523296871009