### PR TITLE
LPS-190915 Implement git process calls in SourceFormatterUtil

### DIFF
--- a/modules/util/source-formatter-standalone/build.gradle
+++ b/modules/util/source-formatter-standalone/build.gradle
@@ -5,11 +5,18 @@ dependencies {
 	compileInclude group: "commons-io", name: "commons-io", version: "2.11.0"
 	compileInclude group: "commons-lang", name: "commons-lang", version: "2.6"
 	compileInclude group: "commons-logging", name: "commons-logging", version: "1.2"
+	compileInclude group: "commons-beanutils", name: "commons-beanutils", version: "1.9.4"
+	compileInclude group: 'commons-collections', name: 'commons-collections', version: '3.2.2'
+	compileInclude group: "com.google.collections", name: "google-collections", version: "1.0"
+	compileInclude group: "org.slf4j", name: "slf4j-api", version: "1.7.26"
+	compileInclude group: "org.javassist", name: "javassist", version: "3.28.0-GA"
+	compileInclude group: "org.apache.commons", name: "commons-lang3", version: "3.0"
 	compileInclude(group: "jaxen", name: "jaxen", version: "1.1.1") {
 		exclude group: "com.ibm.icu", module: "icu4j"
 	}
 	compileInclude group: "junit", name: "junit", version: "4.13.1"
 	compileInclude group: "org.antlr", name: "antlr4-runtime", version: "4.8-1"
+	compileInclude group: 'antlr', name: 'antlr', version: '2.7.7'
 	compileInclude group: "org.apache.ant", name: "ant", version: "1.10.11"
 	compileInclude group: "org.apache.maven", name: "maven-artifact", version: "3.3.9"
 	compileInclude group: "org.dom4j", name: "dom4j", version: "2.1.3"
@@ -17,6 +24,7 @@ dependencies {
 	compileInclude group: "org.reflections", name: "reflections", "version": "0.10.2"
 	compileInclude group: "xerces", name: "xercesImpl", version: "2.12.2"
 
+	compileInclude group: "com.liferay", name: "com.liferay.petra.concurrent", version: "5.1.0"
 	compileInclude group: "com.liferay", name: "com.liferay.petra.function", version: "5.5.0"
 	compileInclude group: "com.liferay", name: "com.liferay.petra.lang", version: "1.0.0"
 	compileInclude group: "com.liferay", name: "com.liferay.petra.nio", version: "1.0.0"

--- a/modules/util/source-formatter/build.gradle
+++ b/modules/util/source-formatter/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 	compileInclude group: "org.codehaus.groovy", name: "groovy", version: "2.4.21"
 
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
-	compileOnly group: "com.liferay", name: "com.liferay.petra.concurrent", version: "1.1.0"
+	compileOnly group: "com.liferay", name: "com.liferay.petra.concurrent", version: "5.1.0"
 	compileOnly group: "com.liferay", name: "com.liferay.petra.memory", version: "1.0.0"
 	compileOnly group: "com.liferay", name: "com.liferay.petra.reflect", version: "1.1.0"
 	compileOnly group: "com.liferay", name: "com.liferay.petra.xml", version: "1.0.0"

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/SourceFormatter.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/SourceFormatter.java
@@ -1025,15 +1025,17 @@ public class SourceFormatter {
 				new ExcludeSyntaxPattern(
 					ExcludeSyntax.GLOB, "**/node_modules_cache/**"),
 				new ExcludeSyntaxPattern(
+					ExcludeSyntax.GLOB,
+					"**/test*/**/dependencies/**/*.[jlw]ar/**"),
+				new ExcludeSyntaxPattern(
+					ExcludeSyntax.GLOB, "**/test*/**/dependencies/**/*.zip/**"),
+				new ExcludeSyntaxPattern(
 					ExcludeSyntax.REGEX,
 					".*/frontend-theme-unstyled/.*/_unstyled/css/clay/.+"),
 				new ExcludeSyntaxPattern(
 					ExcludeSyntax.REGEX,
 					".*/frontend-theme-unstyled/.*/_unstyled/images/(aui|" +
 						"clay|lexicon)/.+"),
-				new ExcludeSyntaxPattern(
-					ExcludeSyntax.REGEX,
-					".*/tests?/.*/dependencies/.+\\.(jar|lar|war|zip)/.+"),
 				new ExcludeSyntaxPattern(
 					ExcludeSyntax.REGEX,
 					"^((?!/frontend-js-node-shims/src/).)*/node_modules/.*"),

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
@@ -20,6 +20,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TextFormatter;
 import com.liferay.portal.kernel.util.Validator;
@@ -28,9 +29,11 @@ import com.liferay.source.formatter.ExcludeSyntaxPattern;
 import com.liferay.source.formatter.SourceFormatterExcludes;
 import com.liferay.source.formatter.check.util.SourceUtil;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 
 import java.net.URL;
 
@@ -45,12 +48,17 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.regex.Pattern;
+
+import javax.annotation.Nullable;
 
 /**
  * @author Igor Spasic
@@ -334,6 +342,115 @@ public class SourceFormatterUtil {
 		return suppressionsFiles;
 	}
 
+	public static List<String> git(
+		List<String> args, @Nullable String dir,
+		@Nullable PathMatchers pathMatchers, boolean includeSubrepositories) {
+
+		List<String> result = new ArrayList<>();
+
+		git(args, dir, pathMatchers, includeSubrepositories, result::add);
+
+		return result;
+	}
+
+	public static void git(
+		List<String> args, @Nullable String dir,
+		@Nullable PathMatchers pathMatchers, boolean includeSubrepositories,
+		Consumer<String> consumer) {
+
+		List<String> allArgs = new ArrayList<>();
+
+		allArgs.add("git");
+
+		allArgs.addAll(args);
+
+		// Path Filtering
+
+		List<String> filters = new ArrayList<>();
+
+		String excludePrefix = ":(exclude,glob)";
+
+		if (pathMatchers != null) {
+			ListUtil.isNotEmptyForEach(
+				pathMatchers.getExcludeDirGlobs(),
+				excludeGlob -> filters.add(excludePrefix + excludeGlob));
+			ListUtil.isNotEmptyForEach(
+				pathMatchers.getExcludeFileGlobs(),
+				excludeGlob -> filters.add(excludePrefix + excludeGlob));
+
+			Map<String, List<String>> excludeDirPathMatchersGlobsMap =
+				pathMatchers.getExcludeDirGlobsMap();
+
+			for (List<String> excludeDirPathGlobs :
+					excludeDirPathMatchersGlobsMap.values()) {
+
+				ListUtil.isNotEmptyForEach(
+					excludeDirPathGlobs,
+					excludeGlob -> filters.add(excludePrefix + excludeGlob));
+			}
+
+			Map<String, List<String>> excludeFilePathMatchersGlobsMap =
+				pathMatchers.getExcludeFileGlobsMap();
+
+			for (List<String> excludeFileGlobs :
+					excludeFilePathMatchersGlobsMap.values()) {
+
+				ListUtil.isNotEmptyForEach(
+					excludeFileGlobs,
+					excludeGlob -> filters.add(excludePrefix + excludeGlob));
+			}
+
+			ListUtil.isNotEmptyForEach(
+				pathMatchers.getIncludeFileGlobs(),
+				includeGlob -> filters.add(":(glob)" + includeGlob));
+		}
+
+		if (_sfIgnoreDirectories != null) {
+			for (String sfIgnoreDirectory : _sfIgnoreDirectories) {
+				filters.add(excludePrefix + sfIgnoreDirectory);
+			}
+		}
+
+		if ((_subrepoIgnoreDirectories != null) && !includeSubrepositories) {
+			for (String subrepoIgnoreDirectory : _subrepoIgnoreDirectories) {
+				filters.add(excludePrefix + subrepoIgnoreDirectory);
+			}
+		}
+
+		if (ListUtil.isNotEmpty(filters)) {
+			allArgs.add("--");
+
+			allArgs.addAll(filters);
+		}
+
+		ProcessBuilder processBuilder = new ProcessBuilder(allArgs);
+
+		if (Validator.isNotNull(dir)) {
+			processBuilder.directory(new File(dir));
+		}
+		else if (_portalDir != null) {
+			processBuilder.directory(_portalDir);
+		}
+
+		try {
+			Process git = processBuilder.start();
+
+			BufferedReader bufferedReader = new BufferedReader(
+				new InputStreamReader(git.getInputStream()));
+
+			for (String line = bufferedReader.readLine(); line != null;
+				 line = bufferedReader.readLine()) {
+
+				consumer.accept(line);
+			}
+
+			bufferedReader.close();
+		}
+		catch (IOException ioException) {
+			throw new RuntimeException(ioException);
+		}
+	}
+
 	public static void printError(String fileName, File file) {
 		printError(fileName, file.toString());
 	}
@@ -532,7 +649,7 @@ public class SourceFormatterUtil {
 		String[] excludes, String[] includes,
 		SourceFormatterExcludes sourceFormatterExcludes) {
 
-		PathMatchers pathMatchers = new PathMatchers(FileSystems.getDefault());
+		PathMatchers pathMatchers = new PathMatchers();
 
 		for (String exclude : excludes) {
 			pathMatchers.addExcludeSyntaxPattern(
@@ -562,12 +679,62 @@ public class SourceFormatterUtil {
 		return pathMatchers;
 	}
 
+	private static void _populateIgnoreDirectories() {
+		_sfIgnoreDirectories = new ArrayList<>();
+		_subrepoIgnoreDirectories = new ArrayList<>();
+
+		List<String> lines = git(
+			Arrays.asList("rev-parse", "--show-toplevel"), null, null, false);
+
+		_portalDir = new File(lines.get(0));
+
+		String absolutePath = _portalDir.getAbsolutePath();
+
+		git(
+			Arrays.asList(
+				"ls-files", "--", "**/source_formatter.ignore", "**/.gitrepo"),
+			absolutePath, null, false,
+			filePath -> {
+				filePath = filePath.replace(
+					StringPool.BACK_SLASH, StringPool.SLASH);
+
+				if (filePath.endsWith("/source_formatter.ignore")) {
+					File file = new File(absolutePath, filePath);
+
+					_sfIgnoreDirectories.add(file.getParent());
+				}
+
+				if (filePath.endsWith("/.gitrepo")) {
+					String content = null;
+
+					File file = new File(absolutePath, filePath);
+
+					try {
+						content = FileUtil.read(file);
+					}
+					catch (IOException ioException) {
+						throw new RuntimeException(ioException);
+					}
+
+					if (content.contains("autopull = true")) {
+						_subrepoIgnoreDirectories.add(file.getParent());
+					}
+				}
+			});
+	}
+
 	private static List<String> _scanForFiles(
 			final String baseDirName, final PathMatchers pathMatchers,
 			final boolean includeSubrepositories)
 		throws IOException {
 
 		final List<String> fileNames = new ArrayList<>();
+
+		if ((_sfIgnoreDirectories == null) ||
+			(_subrepoIgnoreDirectories == null)) {
+
+			_populateIgnoreDirectories();
+		}
 
 		Files.walkFileTree(
 			Paths.get(baseDirName),
@@ -706,11 +873,12 @@ public class SourceFormatterUtil {
 	private static final Log _log = LogFactoryUtil.getLog(
 		SourceFormatterUtil.class);
 
-	private static class PathMatchers {
+	private static final FileSystem _fileSystem = FileSystems.getDefault();
+	private static File _portalDir;
+	private static List<String> _sfIgnoreDirectories;
+	private static List<String> _subrepoIgnoreDirectories;
 
-		public PathMatchers(FileSystem fileSystem) {
-			_fileSystem = fileSystem;
-		}
+	private static class PathMatchers {
 
 		public void addExcludeSyntaxPattern(
 			ExcludeSyntaxPattern excludeSyntaxPattern) {

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TextFormatter;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.tools.GitUtil;
 import com.liferay.source.formatter.ExcludeSyntax;
 import com.liferay.source.formatter.ExcludeSyntaxPattern;
 import com.liferay.source.formatter.SourceFormatterExcludes;
@@ -679,6 +680,21 @@ public class SourceFormatterUtil {
 		return pathMatchers;
 	}
 
+	private static boolean _isGit() {
+		if (_git == null) {
+			try {
+				GitUtil.getLatestCommitId();
+
+				_git = true;
+			}
+			catch (Exception exception) {
+				_git = false;
+			}
+		}
+
+		return _git;
+	}
+
 	private static void _populateIgnoreDirectories() {
 		_sfIgnoreDirectories = new ArrayList<>();
 		_subrepoIgnoreDirectories = new ArrayList<>();
@@ -728,13 +744,36 @@ public class SourceFormatterUtil {
 			final boolean includeSubrepositories)
 		throws IOException {
 
-		final List<String> fileNames = new ArrayList<>();
+		if (_isGit()) {
+			if ((_sfIgnoreDirectories == null) ||
+				(_subrepoIgnoreDirectories == null)) {
 
-		if ((_sfIgnoreDirectories == null) ||
-			(_subrepoIgnoreDirectories == null)) {
+				_populateIgnoreDirectories();
+			}
 
-			_populateIgnoreDirectories();
+			List<String> gitFiles = new ArrayList<>();
+
+			git(
+				Collections.singletonList("ls-files"), baseDirName,
+				pathMatchers, includeSubrepositories,
+				line -> {
+					try {
+						File file = new File(
+							baseDirName,
+							StringUtil.replace(
+								line, CharPool.BACK_SLASH, CharPool.SLASH));
+
+						gitFiles.add(file.getCanonicalPath());
+					}
+					catch (IOException ioException) {
+						throw new RuntimeException(ioException);
+					}
+				});
+
+			return gitFiles;
 		}
+
+		final List<String> fileNames = new ArrayList<>();
 
 		Files.walkFileTree(
 			Paths.get(baseDirName),
@@ -874,6 +913,7 @@ public class SourceFormatterUtil {
 		SourceFormatterUtil.class);
 
 	private static final FileSystem _fileSystem = FileSystems.getDefault();
+	private static Boolean _git;
 	private static File _portalDir;
 	private static List<String> _sfIgnoreDirectories;
 	private static List<String> _subrepoIgnoreDirectories;

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
@@ -48,6 +48,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -727,6 +728,8 @@ public class SourceFormatterUtil {
 			if (excludeSyntax.equals(ExcludeSyntax.GLOB) &&
 				excludePattern.endsWith("/**")) {
 
+				_excludeDirGlobs.add(excludePattern);
+
 				excludePattern = excludePattern.substring(
 					0, excludePattern.length() - 3);
 
@@ -750,6 +753,10 @@ public class SourceFormatterUtil {
 				_excludeFilePathMatchers.add(
 					_fileSystem.getPathMatcher(
 						excludeSyntax.getValue() + ":" + excludePattern));
+
+				if (Objects.equals(ExcludeSyntax.GLOB, excludeSyntax)) {
+					_excludeFileGlobs.add(excludePattern);
+				}
 			}
 		}
 
@@ -758,7 +765,9 @@ public class SourceFormatterUtil {
 			List<ExcludeSyntaxPattern> excludeSyntaxPatterns) {
 
 			List<PathMatcher> excludeDirPathMatcherList = new ArrayList<>();
+			List<String> excludeDirPathMatcherGlobsList = new ArrayList<>();
 			List<PathMatcher> excludeFilePathMatcherList = new ArrayList<>();
+			List<String> excludeFilePathMatcherGlobsList = new ArrayList<>();
 
 			for (ExcludeSyntaxPattern excludeSyntaxPattern :
 					excludeSyntaxPatterns) {
@@ -776,6 +785,8 @@ public class SourceFormatterUtil {
 
 				if (excludeSyntax.equals(ExcludeSyntax.GLOB) &&
 					excludePattern.endsWith("/**")) {
+
+					excludeDirPathMatcherGlobsList.add(excludePattern);
 
 					excludePattern = excludePattern.substring(
 						0, excludePattern.length() - 3);
@@ -800,18 +811,37 @@ public class SourceFormatterUtil {
 					excludeFilePathMatcherList.add(
 						_fileSystem.getPathMatcher(
 							excludeSyntax.getValue() + ":" + excludePattern));
+
+					if (Objects.equals(
+							ExcludeSyntax.GLOB, excludeSyntax.getValue())) {
+
+						excludeFilePathMatcherGlobsList.add(excludePattern);
+					}
 				}
 			}
 
 			_excludeDirPathMatchersMap.put(
 				propertiesFileLocation, excludeDirPathMatcherList);
+			_excludeDirGlobsMap.put(
+				propertiesFileLocation, excludeDirPathMatcherGlobsList);
 			_excludeFilePathMatchersMap.put(
 				propertiesFileLocation, excludeFilePathMatcherList);
+			_excludeFileGlobsMap.put(
+				propertiesFileLocation, excludeFilePathMatcherGlobsList);
 		}
 
 		public void addInclude(String include) {
 			_includeFilePathMatchers.add(
 				_fileSystem.getPathMatcher("glob:" + include));
+			_includeFileGlobs.add(include);
+		}
+
+		public List<String> getExcludeDirGlobs() {
+			return _excludeDirGlobs;
+		}
+
+		public Map<String, List<String>> getExcludeDirGlobsMap() {
+			return _excludeDirGlobsMap;
 		}
 
 		public List<PathMatcher> getExcludeDirPathMatchers() {
@@ -822,6 +852,14 @@ public class SourceFormatterUtil {
 			return _excludeDirPathMatchersMap;
 		}
 
+		public List<String> getExcludeFileGlobs() {
+			return _excludeFileGlobs;
+		}
+
+		public Map<String, List<String>> getExcludeFileGlobsMap() {
+			return _excludeFileGlobsMap;
+		}
+
 		public List<PathMatcher> getExcludeFilePathMatchers() {
 			return _excludeFilePathMatchers;
 		}
@@ -830,18 +868,31 @@ public class SourceFormatterUtil {
 			return _excludeFilePathMatchersMap;
 		}
 
+		public List<String> getIncludeFileGlobs() {
+			return _includeFileGlobs;
+		}
+
 		public List<PathMatcher> getIncludeFilePathMatchers() {
 			return _includeFilePathMatchers;
 		}
 
-		private List<PathMatcher> _excludeDirPathMatchers = new ArrayList<>();
-		private Map<String, List<PathMatcher>> _excludeDirPathMatchersMap =
+		private final List<String> _excludeDirGlobs = new ArrayList<>();
+		private final Map<String, List<String>> _excludeDirGlobsMap =
 			new HashMap<>();
-		private List<PathMatcher> _excludeFilePathMatchers = new ArrayList<>();
-		private Map<String, List<PathMatcher>> _excludeFilePathMatchersMap =
+		private final List<PathMatcher> _excludeDirPathMatchers =
+			new ArrayList<>();
+		private final Map<String, List<PathMatcher>>
+			_excludeDirPathMatchersMap = new HashMap<>();
+		private final List<String> _excludeFileGlobs = new ArrayList<>();
+		private final Map<String, List<String>> _excludeFileGlobsMap =
 			new HashMap<>();
-		private final FileSystem _fileSystem;
-		private List<PathMatcher> _includeFilePathMatchers = new ArrayList<>();
+		private final List<PathMatcher> _excludeFilePathMatchers =
+			new ArrayList<>();
+		private final Map<String, List<PathMatcher>>
+			_excludeFilePathMatchersMap = new HashMap<>();
+		private final List<String> _includeFileGlobs = new ArrayList<>();
+		private final List<PathMatcher> _includeFilePathMatchers =
+			new ArrayList<>();
 
 	}
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
@@ -755,19 +755,11 @@ public class SourceFormatterUtil {
 			git(
 				Arrays.asList("ls-files", "--full-name"), baseDirName,
 				pathMatchers, includeSubrepositories,
-				line -> {
-					try {
-						File file = new File(
-							_gitToplevel,
-							StringUtil.replace(
-								line, CharPool.BACK_SLASH, CharPool.SLASH));
-
-						gitFiles.add(file.getCanonicalPath());
-					}
-					catch (IOException ioException) {
-						throw new RuntimeException(ioException);
-					}
-				});
+				line -> gitFiles.add(
+					StringBundler.concat(
+						_gitToplevel, StringPool.FORWARD_SLASH,
+						StringUtil.replace(
+							line, CharPool.BACK_SLASH, CharPool.SLASH))));
 
 			return gitFiles;
 		}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
@@ -50,7 +50,6 @@ import java.nio.file.attribute.BasicFileAttributes;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -429,8 +428,8 @@ public class SourceFormatterUtil {
 		if (Validator.isNotNull(dir)) {
 			processBuilder.directory(new File(dir));
 		}
-		else if (_portalDir != null) {
-			processBuilder.directory(_portalDir);
+		else if (_gitToplevel != null) {
+			processBuilder.directory(_gitToplevel);
 		}
 
 		try {
@@ -702,9 +701,9 @@ public class SourceFormatterUtil {
 		List<String> lines = git(
 			Arrays.asList("rev-parse", "--show-toplevel"), null, null, false);
 
-		_portalDir = new File(lines.get(0));
+		_gitToplevel = new File(lines.get(0));
 
-		String absolutePath = _portalDir.getAbsolutePath();
+		String absolutePath = _gitToplevel.getAbsolutePath();
 
 		git(
 			Arrays.asList(
@@ -754,12 +753,12 @@ public class SourceFormatterUtil {
 			List<String> gitFiles = new ArrayList<>();
 
 			git(
-				Collections.singletonList("ls-files"), baseDirName,
+				Arrays.asList("ls-files", "--full-name"), baseDirName,
 				pathMatchers, includeSubrepositories,
 				line -> {
 					try {
 						File file = new File(
-							baseDirName,
+							_gitToplevel,
 							StringUtil.replace(
 								line, CharPool.BACK_SLASH, CharPool.SLASH));
 
@@ -914,7 +913,7 @@ public class SourceFormatterUtil {
 
 	private static final FileSystem _fileSystem = FileSystems.getDefault();
 	private static Boolean _git;
-	private static File _portalDir;
+	private static File _gitToplevel;
 	private static List<String> _sfIgnoreDirectories;
 	private static List<String> _subrepoIgnoreDirectories;
 


### PR DESCRIPTION
This is an update for [LPS-190915](https://issues.liferay.com/browse/LPS-190915).

Hi @ling-alan-huang! This pull is a first attempt at optimizing startup time for SourceFormatter. The ultimate goal is to have SF be usable in an editor context (for "format on save"). In order to accomplish this, we need to get SF as efficient as possible at processing one file.

I profiled SF and found that one of the most expensive operations was finding files and walking the file tree. The way I am improving that is by using `git ls-files`, which is very fast and can consume all the same filters passed into the `_scanForFiles` method. Surprisingly, `git ls-files` is often much faster than filtering an in-memory string list!

Additionally, I updated a couple of hotspots in individual checks as an example of how it can be used. Again, the profiler showed improvement. I will attach the before-and-after profiles to the Jira ticket if you would like to inspect them.

The are based off of a run of `gradlew formatSource` in `account-service`. 
Before: `37s`
After: `10s`

For these changes, we will see the most improvement when formatting small batches of files since the goal is to optimize startup time. We will see diminishing returns when processing lots of files since startup is a small portion of the overall cost.

There may be mistakes/oversights here, so I would really appreciate your feedback and any questions or concerns you may have.