### PR TITLE
LPS-190915 Implement git process calls in SourceFormatterUtil

### DIFF
--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetCategoryLocalServiceTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetCategoryLocalServiceTest.java
@@ -484,7 +484,9 @@ public class AssetCategoryLocalServiceTest {
 	}
 
 	@Test
-	public void testSearchWithSameNameInDifferentAssetVocabulary() throws Exception {
+	public void testSearchWithSameNameInDifferentAssetVocabulary0()
+		throws Exception {
+
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId());

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/SourceFormatter.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/SourceFormatter.java
@@ -1016,15 +1016,17 @@ public class SourceFormatter {
 				new ExcludeSyntaxPattern(
 					ExcludeSyntax.GLOB, "**/node_modules_cache/**"),
 				new ExcludeSyntaxPattern(
+					ExcludeSyntax.GLOB,
+					"**/test*/**/dependencies/**/*.[jlw]ar/**"),
+				new ExcludeSyntaxPattern(
+					ExcludeSyntax.GLOB, "**/test*/**/dependencies/**/*.zip/**"),
+				new ExcludeSyntaxPattern(
 					ExcludeSyntax.REGEX,
 					".*/frontend-theme-unstyled/.*/_unstyled/css/clay/.+"),
 				new ExcludeSyntaxPattern(
 					ExcludeSyntax.REGEX,
 					".*/frontend-theme-unstyled/.*/_unstyled/images/(aui|" +
 						"clay|lexicon)/.+"),
-				new ExcludeSyntaxPattern(
-					ExcludeSyntax.REGEX,
-					".*/tests?/.*/dependencies/.+\\.(jar|lar|war|zip)/.+"),
 				new ExcludeSyntaxPattern(
 					ExcludeSyntax.REGEX,
 					"^((?!/frontend-js-node-shims/src/).)*/node_modules/.*"),

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/SourceFormatter.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/SourceFormatter.java
@@ -1017,9 +1017,9 @@ public class SourceFormatter {
 					ExcludeSyntax.GLOB, "**/node_modules_cache/**"),
 				new ExcludeSyntaxPattern(
 					ExcludeSyntax.GLOB,
-					"**/test*/**/dependencies/**/*.[jlw]ar/**"),
+					"**/test*/**/dependencies/*.[jlw]ar/**"),
 				new ExcludeSyntaxPattern(
-					ExcludeSyntax.GLOB, "**/test*/**/dependencies/**/*.zip/**"),
+					ExcludeSyntax.GLOB, "**/test*/**/dependencies/*.zip/**"),
 				new ExcludeSyntaxPattern(
 					ExcludeSyntax.REGEX,
 					".*/frontend-theme-unstyled/.*/_unstyled/css/clay/.+"),

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
@@ -746,19 +746,11 @@ public class SourceFormatterUtil {
 			git(
 				Arrays.asList("ls-files", "--full-name"), baseDirName,
 				pathMatchers, includeSubrepositories,
-				line -> {
-					try {
-						File file = new File(
-							_gitToplevel,
-							StringUtil.replace(
-								line, CharPool.BACK_SLASH, CharPool.SLASH));
-
-						gitFiles.add(file.getCanonicalPath());
-					}
-					catch (IOException ioException) {
-						throw new RuntimeException(ioException);
-					}
-				});
+				line -> gitFiles.add(
+					StringBundler.concat(
+						_gitToplevel, StringPool.FORWARD_SLASH,
+						StringUtil.replace(
+							line, CharPool.BACK_SLASH, CharPool.SLASH))));
 
 			return gitFiles;
 		}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
@@ -44,7 +44,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
@@ -946,7 +945,7 @@ public class SourceFormatterUtil {
 					_fileSystem.getPathMatcher(
 						excludeSyntax.getValue() + ":" + excludePattern));
 
-				if (Objects.equals(ExcludeSyntax.GLOB, excludeSyntax)) {
+				if (excludeSyntax.equals(ExcludeSyntax.GLOB)) {
 					_excludeFileGlobs.add(excludePattern);
 				}
 			}
@@ -1004,9 +1003,7 @@ public class SourceFormatterUtil {
 						_fileSystem.getPathMatcher(
 							excludeSyntax.getValue() + ":" + excludePattern));
 
-					if (Objects.equals(
-							ExcludeSyntax.GLOB, excludeSyntax.getValue())) {
-
+					if (excludeSyntax.equals(ExcludeSyntax.GLOB)) {
 						excludeFilePathMatcherGlobsList.add(excludePattern);
 					}
 				}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
@@ -412,12 +412,7 @@ public class SourceFormatterUtil {
 
 		ProcessBuilder processBuilder = new ProcessBuilder(allArgs);
 
-		if (Validator.isNotNull(baseDirName)) {
-			processBuilder.directory(new File(baseDirName));
-		}
-		else if (_gitTopLevel != null) {
-			processBuilder.directory(_gitTopLevel);
-		}
+		processBuilder.directory(new File(baseDirName));
 
 		try {
 			Process process = processBuilder.start();
@@ -666,27 +661,20 @@ public class SourceFormatterUtil {
 		return pathMatchers;
 	}
 
-	private static void _populateIgnoreDirectories() {
+	private static void _populateIgnoreDirectories(String baseDirName) {
 		_sfIgnoreDirectories = new ArrayList<>();
 		_subrepoIgnoreDirectories = new ArrayList<>();
-
-		List<String> lines = git(
-			Arrays.asList("rev-parse", "--show-toplevel"), null, null, false);
-
-		_gitTopLevel = new File(lines.get(0));
-
-		String absolutePath = _gitTopLevel.getAbsolutePath();
 
 		git(
 			Arrays.asList(
 				"ls-files", "--", "**/source_formatter.ignore", "**/.gitrepo"),
-			absolutePath, null, false,
+			baseDirName, null, false,
 			filePath -> {
 				filePath = filePath.replace(
 					StringPool.BACK_SLASH, StringPool.SLASH);
 
 				if (filePath.endsWith("/source_formatter.ignore")) {
-					File file = new File(absolutePath, filePath);
+					File file = new File(baseDirName, filePath);
 
 					_sfIgnoreDirectories.add(file.getParent());
 				}
@@ -694,7 +682,7 @@ public class SourceFormatterUtil {
 				if (filePath.endsWith("/.gitrepo")) {
 					String content = null;
 
-					File file = new File(absolutePath, filePath);
+					File file = new File(baseDirName, filePath);
 
 					try {
 						content = FileUtil.read(file);
@@ -722,7 +710,7 @@ public class SourceFormatterUtil {
 				if ((_sfIgnoreDirectories == null) ||
 					(_subrepoIgnoreDirectories == null)) {
 
-					_populateIgnoreDirectories();
+					_populateIgnoreDirectories(baseDirName);
 				}
 
 				List<String> gitFiles = new ArrayList<>();
@@ -732,7 +720,7 @@ public class SourceFormatterUtil {
 					pathMatchers, includeSubrepositories,
 					line -> gitFiles.add(
 						StringBundler.concat(
-							_gitTopLevel, StringPool.FORWARD_SLASH,
+							baseDirName, StringPool.FORWARD_SLASH,
 							StringUtil.replace(
 								line, CharPool.BACK_SLASH, CharPool.SLASH))));
 
@@ -891,7 +879,6 @@ public class SourceFormatterUtil {
 		SourceFormatterUtil.class);
 
 	private static final FileSystem _fileSystem = FileSystems.getDefault();
-	private static File _gitTopLevel;
 	private static List<String> _sfIgnoreDirectories;
 	private static List<String> _subrepoIgnoreDirectories;
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
@@ -425,10 +425,10 @@ public class SourceFormatterUtil {
 		}
 
 		try {
-			Process git = processBuilder.start();
+			Process process = processBuilder.start();
 
 			BufferedReader bufferedReader = new BufferedReader(
-				new InputStreamReader(git.getInputStream()));
+				new InputStreamReader(process.getInputStream()));
 
 			String line = null;
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
@@ -431,9 +431,9 @@ public class SourceFormatterUtil {
 			BufferedReader bufferedReader = new BufferedReader(
 				new InputStreamReader(git.getInputStream()));
 
-			for (String line = bufferedReader.readLine(); line != null;
-				 line = bufferedReader.readLine()) {
+			String line = null;
 
+			while ((line = bufferedReader.readLine()) != null) {
 				consumer.accept(line);
 			}
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
@@ -367,26 +367,24 @@ public class SourceFormatterUtil {
 				pathMatchers.getExcludeFileGlobs(),
 				excludeGlob -> filters.add(excludePrefix + excludeGlob));
 
-			Map<String, List<String>> excludeDirPathMatchersGlobsMap =
+			Map<String, List<String>> excludeDirGlobsMap =
 				pathMatchers.getExcludeDirGlobsMap();
 
-			for (List<String> excludeDirPathGlobs :
-					excludeDirPathMatchersGlobsMap.values()) {
-
+			for (List<String> excludeDirGlobs : excludeDirGlobsMap.values()) {
 				ListUtil.isNotEmptyForEach(
-					excludeDirPathGlobs,
-					excludeGlob -> filters.add(excludePrefix + excludeGlob));
+					excludeDirGlobs,
+					excludeDirGlob -> filters.add(
+						excludePrefix + excludeDirGlob));
 			}
 
-			Map<String, List<String>> excludeFilePathMatchersGlobsMap =
+			Map<String, List<String>> excludeFileGlobsMap =
 				pathMatchers.getExcludeFileGlobsMap();
 
-			for (List<String> excludeFileGlobs :
-					excludeFilePathMatchersGlobsMap.values()) {
-
+			for (List<String> excludeFileGlobs : excludeFileGlobsMap.values()) {
 				ListUtil.isNotEmptyForEach(
 					excludeFileGlobs,
-					excludeGlob -> filters.add(excludePrefix + excludeGlob));
+					excludeFileGlob -> filters.add(
+						excludePrefix + excludeFileGlob));
 			}
 
 			ListUtil.isNotEmptyForEach(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -718,6 +719,8 @@ public class SourceFormatterUtil {
 			if (excludeSyntax.equals(ExcludeSyntax.GLOB) &&
 				excludePattern.endsWith("/**")) {
 
+				_excludeDirGlobs.add(excludePattern);
+
 				excludePattern = excludePattern.substring(
 					0, excludePattern.length() - 3);
 
@@ -741,6 +744,10 @@ public class SourceFormatterUtil {
 				_excludeFilePathMatchers.add(
 					_fileSystem.getPathMatcher(
 						excludeSyntax.getValue() + ":" + excludePattern));
+
+				if (Objects.equals(ExcludeSyntax.GLOB, excludeSyntax)) {
+					_excludeFileGlobs.add(excludePattern);
+				}
 			}
 		}
 
@@ -749,7 +756,9 @@ public class SourceFormatterUtil {
 			List<ExcludeSyntaxPattern> excludeSyntaxPatterns) {
 
 			List<PathMatcher> excludeDirPathMatcherList = new ArrayList<>();
+			List<String> excludeDirPathMatcherGlobsList = new ArrayList<>();
 			List<PathMatcher> excludeFilePathMatcherList = new ArrayList<>();
+			List<String> excludeFilePathMatcherGlobsList = new ArrayList<>();
 
 			for (ExcludeSyntaxPattern excludeSyntaxPattern :
 					excludeSyntaxPatterns) {
@@ -767,6 +776,8 @@ public class SourceFormatterUtil {
 
 				if (excludeSyntax.equals(ExcludeSyntax.GLOB) &&
 					excludePattern.endsWith("/**")) {
+
+					excludeDirPathMatcherGlobsList.add(excludePattern);
 
 					excludePattern = excludePattern.substring(
 						0, excludePattern.length() - 3);
@@ -791,18 +802,37 @@ public class SourceFormatterUtil {
 					excludeFilePathMatcherList.add(
 						_fileSystem.getPathMatcher(
 							excludeSyntax.getValue() + ":" + excludePattern));
+
+					if (Objects.equals(
+							ExcludeSyntax.GLOB, excludeSyntax.getValue())) {
+
+						excludeFilePathMatcherGlobsList.add(excludePattern);
+					}
 				}
 			}
 
 			_excludeDirPathMatchersMap.put(
 				propertiesFileLocation, excludeDirPathMatcherList);
+			_excludeDirGlobsMap.put(
+				propertiesFileLocation, excludeDirPathMatcherGlobsList);
 			_excludeFilePathMatchersMap.put(
 				propertiesFileLocation, excludeFilePathMatcherList);
+			_excludeFileGlobsMap.put(
+				propertiesFileLocation, excludeFilePathMatcherGlobsList);
 		}
 
 		public void addInclude(String include) {
 			_includeFilePathMatchers.add(
 				_fileSystem.getPathMatcher("glob:" + include));
+			_includeFileGlobs.add(include);
+		}
+
+		public List<String> getExcludeDirGlobs() {
+			return _excludeDirGlobs;
+		}
+
+		public Map<String, List<String>> getExcludeDirGlobsMap() {
+			return _excludeDirGlobsMap;
 		}
 
 		public List<PathMatcher> getExcludeDirPathMatchers() {
@@ -813,6 +843,14 @@ public class SourceFormatterUtil {
 			return _excludeDirPathMatchersMap;
 		}
 
+		public List<String> getExcludeFileGlobs() {
+			return _excludeFileGlobs;
+		}
+
+		public Map<String, List<String>> getExcludeFileGlobsMap() {
+			return _excludeFileGlobsMap;
+		}
+
 		public List<PathMatcher> getExcludeFilePathMatchers() {
 			return _excludeFilePathMatchers;
 		}
@@ -821,18 +859,31 @@ public class SourceFormatterUtil {
 			return _excludeFilePathMatchersMap;
 		}
 
+		public List<String> getIncludeFileGlobs() {
+			return _includeFileGlobs;
+		}
+
 		public List<PathMatcher> getIncludeFilePathMatchers() {
 			return _includeFilePathMatchers;
 		}
 
-		private List<PathMatcher> _excludeDirPathMatchers = new ArrayList<>();
-		private Map<String, List<PathMatcher>> _excludeDirPathMatchersMap =
+		private final List<String> _excludeDirGlobs = new ArrayList<>();
+		private final Map<String, List<String>> _excludeDirGlobsMap =
 			new HashMap<>();
-		private List<PathMatcher> _excludeFilePathMatchers = new ArrayList<>();
-		private Map<String, List<PathMatcher>> _excludeFilePathMatchersMap =
+		private final List<PathMatcher> _excludeDirPathMatchers =
+			new ArrayList<>();
+		private final Map<String, List<PathMatcher>>
+			_excludeDirPathMatchersMap = new HashMap<>();
+		private final List<String> _excludeFileGlobs = new ArrayList<>();
+		private final Map<String, List<String>> _excludeFileGlobsMap =
 			new HashMap<>();
-		private final FileSystem _fileSystem;
-		private List<PathMatcher> _includeFilePathMatchers = new ArrayList<>();
+		private final List<PathMatcher> _excludeFilePathMatchers =
+			new ArrayList<>();
+		private final Map<String, List<PathMatcher>>
+			_excludeFilePathMatchersMap = new HashMap<>();
+		private final List<String> _includeFileGlobs = new ArrayList<>();
+		private final List<PathMatcher> _includeFilePathMatchers =
+			new ArrayList<>();
 
 	}
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
@@ -716,8 +716,8 @@ public class SourceFormatterUtil {
 				List<String> gitFiles = new ArrayList<>();
 
 				git(
-					Arrays.asList("ls-files", "--full-name"), baseDirName,
-					pathMatchers, includeSubrepositories,
+					Arrays.asList("ls-files"), baseDirName, pathMatchers,
+					includeSubrepositories,
 					line -> gitFiles.add(
 						StringBundler.concat(
 							baseDirName, StringPool.FORWARD_SLASH,

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
@@ -41,7 +41,6 @@ import java.nio.file.attribute.BasicFileAttributes;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -420,8 +419,8 @@ public class SourceFormatterUtil {
 		if (Validator.isNotNull(dir)) {
 			processBuilder.directory(new File(dir));
 		}
-		else if (_portalDir != null) {
-			processBuilder.directory(_portalDir);
+		else if (_gitToplevel != null) {
+			processBuilder.directory(_gitToplevel);
 		}
 
 		try {
@@ -693,9 +692,9 @@ public class SourceFormatterUtil {
 		List<String> lines = git(
 			Arrays.asList("rev-parse", "--show-toplevel"), null, null, false);
 
-		_portalDir = new File(lines.get(0));
+		_gitToplevel = new File(lines.get(0));
 
-		String absolutePath = _portalDir.getAbsolutePath();
+		String absolutePath = _gitToplevel.getAbsolutePath();
 
 		git(
 			Arrays.asList(
@@ -745,12 +744,12 @@ public class SourceFormatterUtil {
 			List<String> gitFiles = new ArrayList<>();
 
 			git(
-				Collections.singletonList("ls-files"), baseDirName,
+				Arrays.asList("ls-files", "--full-name"), baseDirName,
 				pathMatchers, includeSubrepositories,
 				line -> {
 					try {
 						File file = new File(
-							baseDirName,
+							_gitToplevel,
 							StringUtil.replace(
 								line, CharPool.BACK_SLASH, CharPool.SLASH));
 
@@ -905,7 +904,7 @@ public class SourceFormatterUtil {
 
 	private static final FileSystem _fileSystem = FileSystems.getDefault();
 	private static Boolean _git;
-	private static File _portalDir;
+	private static File _gitToplevel;
 	private static List<String> _sfIgnoreDirectories;
 	private static List<String> _subrepoIgnoreDirectories;
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
@@ -48,8 +48,6 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
-import javax.annotation.Nullable;
-
 /**
  * @author Igor Spasic
  * @author Brian Wing Shun Chan
@@ -333,8 +331,8 @@ public class SourceFormatterUtil {
 	}
 
 	public static List<String> git(
-		List<String> args, @Nullable String baseDirName,
-		@Nullable PathMatchers pathMatchers, boolean includeSubrepositories) {
+		List<String> args, String baseDirName, PathMatchers pathMatchers,
+		boolean includeSubrepositories) {
 
 		List<String> result = new ArrayList<>();
 
@@ -346,9 +344,8 @@ public class SourceFormatterUtil {
 	}
 
 	public static void git(
-		List<String> args, @Nullable String baseDirName,
-		@Nullable PathMatchers pathMatchers, boolean includeSubrepositories,
-		Consumer<String> consumer) {
+		List<String> args, String baseDirName, PathMatchers pathMatchers,
+		boolean includeSubrepositories, Consumer<String> consumer) {
 
 		List<String> allArgs = new ArrayList<>();
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
@@ -334,18 +334,20 @@ public class SourceFormatterUtil {
 	}
 
 	public static List<String> git(
-		List<String> args, @Nullable String dir,
+		List<String> args, @Nullable String baseDirName,
 		@Nullable PathMatchers pathMatchers, boolean includeSubrepositories) {
 
 		List<String> result = new ArrayList<>();
 
-		git(args, dir, pathMatchers, includeSubrepositories, result::add);
+		git(
+			args, baseDirName, pathMatchers, includeSubrepositories,
+			result::add);
 
 		return result;
 	}
 
 	public static void git(
-		List<String> args, @Nullable String dir,
+		List<String> args, @Nullable String baseDirName,
 		@Nullable PathMatchers pathMatchers, boolean includeSubrepositories,
 		Consumer<String> consumer) {
 
@@ -416,8 +418,8 @@ public class SourceFormatterUtil {
 
 		ProcessBuilder processBuilder = new ProcessBuilder(allArgs);
 
-		if (Validator.isNotNull(dir)) {
-			processBuilder.directory(new File(dir));
+		if (Validator.isNotNull(baseDirName)) {
+			processBuilder.directory(new File(baseDirName));
 		}
 		else if (_gitToplevel != null) {
 			processBuilder.directory(_gitToplevel);

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
@@ -415,8 +415,8 @@ public class SourceFormatterUtil {
 		if (Validator.isNotNull(baseDirName)) {
 			processBuilder.directory(new File(baseDirName));
 		}
-		else if (_gitToplevel != null) {
-			processBuilder.directory(_gitToplevel);
+		else if (_gitTopLevel != null) {
+			processBuilder.directory(_gitTopLevel);
 		}
 
 		try {
@@ -688,9 +688,9 @@ public class SourceFormatterUtil {
 		List<String> lines = git(
 			Arrays.asList("rev-parse", "--show-toplevel"), null, null, false);
 
-		_gitToplevel = new File(lines.get(0));
+		_gitTopLevel = new File(lines.get(0));
 
-		String absolutePath = _gitToplevel.getAbsolutePath();
+		String absolutePath = _gitTopLevel.getAbsolutePath();
 
 		git(
 			Arrays.asList(
@@ -744,7 +744,7 @@ public class SourceFormatterUtil {
 				pathMatchers, includeSubrepositories,
 				line -> gitFiles.add(
 					StringBundler.concat(
-						_gitToplevel, StringPool.FORWARD_SLASH,
+						_gitTopLevel, StringPool.FORWARD_SLASH,
 						StringUtil.replace(
 							line, CharPool.BACK_SLASH, CharPool.SLASH))));
 
@@ -892,7 +892,7 @@ public class SourceFormatterUtil {
 
 	private static final FileSystem _fileSystem = FileSystems.getDefault();
 	private static Boolean _git;
-	private static File _gitToplevel;
+	private static File _gitTopLevel;
 	private static List<String> _sfIgnoreDirectories;
 	private static List<String> _subrepoIgnoreDirectories;
 


### PR DESCRIPTION
> From [drewbrokke](https://github.com/drewbrokke)


This is an update for [LPS-190915](https://issues.liferay.com/browse/LPS-190915).

Hi @ling-alan-huang! This pull is a first attempt at optimizing startup time for SourceFormatter. The ultimate goal is to have SF be usable in an editor context (for "format on save"). In order to accomplish this, we need to get SF as efficient as possible at processing one file.

I profiled SF and found that one of the most expensive operations was finding files and walking the file tree. The way I am improving that is by using `git ls-files`, which is very fast and can consume all the same filters passed into the `_scanForFiles` method. Surprisingly, `git ls-files` is often much faster than filtering an in-memory string list!

The are based off of a run of `gradlew formatSource` in `account-service`. 
Before: `37s`
After: `10s`

For these changes, we will see the most improvement when formatting small batches of files since the goal is to optimize startup time. We will see diminishing returns when processing lots of files since startup is a small portion of the overall cost.

There may be mistakes/oversights here, so I would really appreciate your feedback and any questions or concerns you may have.