### PR TITLE
LPS-192112 We should skip checking the variable when it is in comment

### DIFF
--- a/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetCategoryLocalServiceTest.java
+++ b/modules/apps/asset/asset-categories-test/src/testIntegration/java/com/liferay/asset/categories/service/test/AssetCategoryLocalServiceTest.java
@@ -484,7 +484,9 @@ public class AssetCategoryLocalServiceTest {
 	}
 
 	@Test
-	public void testSearchWithSameNameInDifferentAssetVocabulary() throws Exception {
+	public void testSearchWithSameNameInDifferentAssetVocabulary0()
+		throws Exception {
+
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(
 				_group.getGroupId(), TestPropsValues.getUserId());

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BaseJSPTermsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BaseJSPTermsCheck.java
@@ -144,24 +144,6 @@ public abstract class BaseJSPTermsCheck extends BaseFileCheck {
 		return false;
 	}
 
-	protected boolean isInsideComment(String content, int pos) {
-		String s = content.substring(pos);
-
-		int x = s.indexOf("*/");
-
-		if (x == -1) {
-			return false;
-		}
-
-		s = s.substring(0, x);
-
-		if (!s.contains("/*")) {
-			return true;
-		}
-
-		return false;
-	}
-
 	protected synchronized void populateContentsMap(
 			String fileName, String content)
 		throws IOException {
@@ -260,6 +242,24 @@ public abstract class BaseJSPTermsCheck extends BaseFileCheck {
 		}
 	}
 
+	private boolean _isInsideComment(String content, int pos) {
+		String s = content.substring(pos);
+
+		int x = s.indexOf("*/");
+
+		if (x == -1) {
+			return false;
+		}
+
+		s = s.substring(0, x);
+
+		if (!s.contains("/*")) {
+			return true;
+		}
+
+		return false;
+	}
+
 	private boolean _isJSPTermRequired(
 		String fileName, String content, String regex, int lineNumber,
 		String type, Set<String> checkedForUnusedJSPTerm,
@@ -310,7 +310,7 @@ public abstract class BaseJSPTermsCheck extends BaseFileCheck {
 			String line = StringUtil.trim(
 				getLine(content, getLineNumber(content, matcher.start())));
 
-			if (line.startsWith("function ") || isInsideComment(content, x)) {
+			if (line.startsWith("function ") || _isInsideComment(content, x)) {
 				continue;
 			}
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BaseJSPTermsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BaseJSPTermsCheck.java
@@ -299,6 +299,10 @@ public abstract class BaseJSPTermsCheck extends BaseFileCheck {
 
 			int x = matcher.start() + 1;
 
+			if (_isInsideComment(content, x)) {
+				continue;
+			}
+
 			if (isJavaSource(content, x)) {
 				if (!ToolsUtil.isInsideQuotes(content, x)) {
 					count++;
@@ -310,7 +314,7 @@ public abstract class BaseJSPTermsCheck extends BaseFileCheck {
 			String line = StringUtil.trim(
 				getLine(content, getLineNumber(content, matcher.start())));
 
-			if (line.startsWith("function ") || _isInsideComment(content, x)) {
+			if (line.startsWith("function ")) {
 				continue;
 			}
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BaseJSPTermsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BaseJSPTermsCheck.java
@@ -144,6 +144,24 @@ public abstract class BaseJSPTermsCheck extends BaseFileCheck {
 		return false;
 	}
 
+	protected boolean isInsideComment(String content, int pos) {
+		String s = content.substring(pos);
+
+		int x = s.indexOf("*/");
+
+		if (x == -1) {
+			return false;
+		}
+
+		s = s.substring(0, x);
+
+		if (!s.contains("/*")) {
+			return true;
+		}
+
+		return false;
+	}
+
 	protected synchronized void populateContentsMap(
 			String fileName, String content)
 		throws IOException {
@@ -292,7 +310,7 @@ public abstract class BaseJSPTermsCheck extends BaseFileCheck {
 			String line = StringUtil.trim(
 				getLine(content, getLineNumber(content, matcher.start())));
 
-			if (line.startsWith("function ")) {
+			if (line.startsWith("function ") || isInsideComment(content, x)) {
 				continue;
 			}
 


### PR DESCRIPTION
This bcf862b56dffa07ac45d2daee72a958e6d078468 unsued variable should be catched long ago.
SF didn't catch it because the old copyright had `version`.