### PR TITLE
LPS-206304 [SF] Remove exposed 'long userId' in remote service - asset-list-service

### DIFF
--- a/modules/apps/asset/asset-list-api/bnd.bnd
+++ b/modules/apps/asset/asset-list-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Asset List API
 Bundle-SymbolicName: com.liferay.asset.list.api
-Bundle-Version: 12.2.1
+Bundle-Version: 13.0.0
 Export-Package:\
 	com.liferay.asset.list.asset.entry.provider,\
 	com.liferay.asset.list.constants,\

--- a/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/service/AssetListEntryService.java
+++ b/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/service/AssetListEntryService.java
@@ -61,12 +61,12 @@ public interface AssetListEntryService extends BaseService {
 		throws PortalException;
 
 	public AssetListEntry addDynamicAssetListEntry(
-			long userId, long groupId, String title, String typeSettings,
+			long groupId, String title, String typeSettings,
 			ServiceContext serviceContext)
 		throws PortalException;
 
 	public AssetListEntry addManualAssetListEntry(
-			long userId, long groupId, String title, long[] assetEntryIds,
+			long groupId, String title, long[] assetEntryIds,
 			ServiceContext serviceContext)
 		throws PortalException;
 

--- a/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/service/AssetListEntryServiceUtil.java
+++ b/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/service/AssetListEntryServiceUtil.java
@@ -58,21 +58,21 @@ public class AssetListEntryServiceUtil {
 	}
 
 	public static AssetListEntry addDynamicAssetListEntry(
-			long userId, long groupId, String title, String typeSettings,
+			long groupId, String title, String typeSettings,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().addDynamicAssetListEntry(
-			userId, groupId, title, typeSettings, serviceContext);
+			groupId, title, typeSettings, serviceContext);
 	}
 
 	public static AssetListEntry addManualAssetListEntry(
-			long userId, long groupId, String title, long[] assetEntryIds,
+			long groupId, String title, long[] assetEntryIds,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().addManualAssetListEntry(
-			userId, groupId, title, assetEntryIds, serviceContext);
+			groupId, title, assetEntryIds, serviceContext);
 	}
 
 	public static void deleteAssetEntrySelection(

--- a/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/service/AssetListEntryServiceWrapper.java
+++ b/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/service/AssetListEntryServiceWrapper.java
@@ -60,22 +60,22 @@ public class AssetListEntryServiceWrapper
 
 	@Override
 	public AssetListEntry addDynamicAssetListEntry(
-			long userId, long groupId, String title, String typeSettings,
+			long groupId, String title, String typeSettings,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _assetListEntryService.addDynamicAssetListEntry(
-			userId, groupId, title, typeSettings, serviceContext);
+			groupId, title, typeSettings, serviceContext);
 	}
 
 	@Override
 	public AssetListEntry addManualAssetListEntry(
-			long userId, long groupId, String title, long[] assetEntryIds,
+			long groupId, String title, long[] assetEntryIds,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _assetListEntryService.addManualAssetListEntry(
-			userId, groupId, title, assetEntryIds, serviceContext);
+			groupId, title, assetEntryIds, serviceContext);
 	}
 
 	@Override

--- a/modules/apps/asset/asset-list-api/src/main/resources/com/liferay/asset/list/service/packageinfo
+++ b/modules/apps/asset/asset-list-api/src/main/resources/com/liferay/asset/list/service/packageinfo
@@ -1,1 +1,1 @@
-version 3.1.0
+version 4.0.0

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/service/http/AssetListEntryServiceHttp.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/service/http/AssetListEntryServiceHttp.java
@@ -162,8 +162,8 @@ public class AssetListEntryServiceHttp {
 
 	public static com.liferay.asset.list.model.AssetListEntry
 			addDynamicAssetListEntry(
-				HttpPrincipal httpPrincipal, long userId, long groupId,
-				String title, String typeSettings,
+				HttpPrincipal httpPrincipal, long groupId, String title,
+				String typeSettings,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -173,8 +173,7 @@ public class AssetListEntryServiceHttp {
 				_addDynamicAssetListEntryParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, userId, groupId, title, typeSettings,
-				serviceContext);
+				methodKey, groupId, title, typeSettings, serviceContext);
 
 			Object returnObj = null;
 
@@ -206,8 +205,8 @@ public class AssetListEntryServiceHttp {
 
 	public static com.liferay.asset.list.model.AssetListEntry
 			addManualAssetListEntry(
-				HttpPrincipal httpPrincipal, long userId, long groupId,
-				String title, long[] assetEntryIds,
+				HttpPrincipal httpPrincipal, long groupId, String title,
+				long[] assetEntryIds,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -217,8 +216,7 @@ public class AssetListEntryServiceHttp {
 				_addManualAssetListEntryParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, userId, groupId, title, assetEntryIds,
-				serviceContext);
+				methodKey, groupId, title, assetEntryIds, serviceContext);
 
 			Object returnObj = null;
 
@@ -1304,12 +1302,12 @@ public class AssetListEntryServiceHttp {
 		};
 	private static final Class<?>[] _addDynamicAssetListEntryParameterTypes3 =
 		new Class[] {
-			long.class, long.class, String.class, String.class,
+			long.class, String.class, String.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[] _addManualAssetListEntryParameterTypes4 =
 		new Class[] {
-			long.class, long.class, String.class, long[].class,
+			long.class, String.class, long[].class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[] _deleteAssetEntrySelectionParameterTypes5 =

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/service/impl/AssetListEntryServiceImpl.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/service/impl/AssetListEntryServiceImpl.java
@@ -80,7 +80,7 @@ public class AssetListEntryServiceImpl extends AssetListEntryServiceBaseImpl {
 
 	@Override
 	public AssetListEntry addDynamicAssetListEntry(
-			long userId, long groupId, String title, String typeSettings,
+			long groupId, String title, String typeSettings,
 			ServiceContext serviceContext)
 		throws PortalException {
 
@@ -94,7 +94,7 @@ public class AssetListEntryServiceImpl extends AssetListEntryServiceBaseImpl {
 
 	@Override
 	public AssetListEntry addManualAssetListEntry(
-			long userId, long groupId, String title, long[] assetEntryIds,
+			long groupId, String title, long[] assetEntryIds,
 			ServiceContext serviceContext)
 		throws PortalException {
 

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/portlet/action/AddAssetListEntryMVCActionCommand.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/portlet/action/AddAssetListEntryMVCActionCommand.java
@@ -65,7 +65,6 @@ public class AddAssetListEntryMVCActionCommand extends BaseMVCActionCommand {
 
 				assetListEntry =
 					_assetListEntryService.addDynamicAssetListEntry(
-						serviceContext.getUserId(),
 						serviceContext.getScopeGroupId(), title,
 						UnicodePropertiesBuilder.create(
 							true

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/action/AddAssetListMVCActionCommand.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/action/AddAssetListMVCActionCommand.java
@@ -203,8 +203,8 @@ public class AddAssetListMVCActionCommand extends BaseMVCActionCommand {
 		}
 
 		_assetListEntryService.addDynamicAssetListEntry(
-			themeDisplay.getUserId(), themeDisplay.getScopeGroupId(), title,
-			unicodeProperties.toString(), serviceContext);
+			themeDisplay.getScopeGroupId(), title, unicodeProperties.toString(),
+			serviceContext);
 	}
 
 	private void _saveManualAssetList(
@@ -229,8 +229,8 @@ public class AddAssetListMVCActionCommand extends BaseMVCActionCommand {
 			AssetEntry::getEntryId);
 
 		_assetListEntryService.addManualAssetListEntry(
-			themeDisplay.getUserId(), themeDisplay.getScopeGroupId(), title,
-			assetEntryIds, serviceContext);
+			themeDisplay.getScopeGroupId(), title, assetEntryIds,
+			serviceContext);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(


### PR DESCRIPTION
SF request: https://github.com/liferay/liferay-portal/commit/0a9424f9f0625740e087013721ee272a1db7a030

> remote service should never expose 'long userId' like this because it allows a remote invocation to be made to this service (via jsonws) as anyone.
The caller can say, deleteXyz(long userId) and pass in any user id