### PR TITLE
LPD-5438 SF, provide more information

### DIFF
--- a/modules/apps/object/object-test-util/src/main/java/com/liferay/object/test/util/TreeTestUtil.java
+++ b/modules/apps/object/object-test-util/src/main/java/com/liferay/object/test/util/TreeTestUtil.java
@@ -288,7 +288,8 @@ public class TreeTestUtil {
 					node.getChildNodes(), unsafeFunction, String.class));
 		}
 
-		Assert.assertEquals(expectedMap.size(), actualMap.size());
+		Assert.assertEquals(
+			actualMap.toString(), expectedMap.size(), actualMap.size());
 
 		for (Map.Entry<String, String[]> entry : expectedMap.entrySet()) {
 			String[] expectedValues = entry.getValue();


### PR DESCRIPTION
SF message:

> Add 'actualMap.toString()' as extra parameter at the beginning of the 'Assert.assertEquals' call to provide more information to the test. See LPS-70411., see https://github.com/liferay/liferay-portal/blob/master/modules/util/source-formatter/src/main/resources/documentation/check/assert_equals_check.markdown: ./modules/apps/object/object-test-util/src/main/java/com/liferay/object/test/util/TreeTestUtil.java 291 (Checkstyle:AssertEqualsCheck)