### PR TITLE
LPD-21969 Improve breaking change SF rule

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BNDBreakingChangeCommitMessageCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BNDBreakingChangeCommitMessageCheck.java
@@ -8,6 +8,7 @@ package com.liferay.source.formatter.check;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.tools.GitUtil;
@@ -210,6 +211,26 @@ public class BNDBreakingChangeCommitMessageCheck extends BaseFileCheck {
 						"There should be an empty line after/before '----', ",
 						"'# breaking', '## What', '## Why' and '## ",
 						"Alternatives'"));
+			}
+
+			if (header.equals("## Alternatives") || header.equals("## What") ||
+				header.equals("## Why")) {
+
+				String explanationLine = SourceUtil.getLine(
+					parts[1], lineNumber + 2);
+
+				if (Validator.isNull(explanationLine) ||
+					ArrayUtil.contains(
+						_BREAKING_CHANGE_HEADER_NAMES, explanationLine)) {
+
+					addMessage(
+						fileName,
+						StringBundler.concat(
+							"Incorrect commit message in SHA ", parts[0], ": ",
+							"There should be at least a line containing an ",
+							"explanation after '## What', '## Why' and '## ",
+							"Alternatives'"));
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Related ticket: https://liferay.atlassian.net/browse/LPD-21969

---

The purpose of this PR is to improve the SF rule that checks the breaking changes commit by including a new validation. The validation is that after `## Alternatives` `## What` and `## Why`, a line containing an explanation must exist.