### PR TITLE
LPD-20228 SF

### DIFF
--- a/util-taglib/src/com/liferay/taglib/ui/LanguageTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/LanguageTag.java
@@ -160,10 +160,8 @@ public class LanguageTag extends IncludeTag {
 
 		Layout layout = themeDisplay.getLayout();
 
-		formAction = HttpComponentsUtil.setParameter(
+		return HttpComponentsUtil.setParameter(
 			formAction, "layoutId", layout.getLayoutId());
-
-		return formAction;
 	}
 
 	protected List<LanguageEntry> getLanguageEntries(


### PR DESCRIPTION
> No need to assign call to variable 'formAction', because 'formAction' is returned right after, see https://github.com/liferay/liferay-portal/blob/master/modules/util/source-formatter/src/main/resources/documentation/check/unnecessary_assign_check.markdown: ./util-taglib/src/com/liferay/taglib/ui/LanguageTag.java 163 (Checkstyle:UnnecessaryAssignCheck)