### PR TITLE
LPD-29718 Create SF rule to avoid caching non-company scoped classNameIds

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/ClassNameIdCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/ClassNameIdCheck.java
@@ -64,14 +64,35 @@ public class ClassNameIdCheck extends BaseCheck {
 
 			String variableName = getName(variableDefDetailAST);
 
-			if (variableName.contains("ClassNameId") ||
-				variableName.contains("classNameId")) {
+			if (!variableName.contains("ClassNameId") &&
+				!variableName.contains("classNameId")) {
 
+				continue;
+			}
+
+			if (!_isAssignedInsideConstructor(variableDefDetailAST)) {
 				log(
 					variableDefDetailAST, _MSG_AVOID_VARIABLE_NAME,
 					variableName);
 			}
 		}
+	}
+
+	private boolean _isAssignedInsideConstructor(
+		DetailAST variableDefDetailAST) {
+
+		List<DetailAST> variableCallerDetailASTList =
+			getVariableCallerDetailASTList(variableDefDetailAST);
+
+		for (DetailAST variableCallerDetailAST : variableCallerDetailASTList) {
+			if (hasParentWithTokenType(
+					variableCallerDetailAST, TokenTypes.CTOR_DEF)) {
+
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	private static final String _MSG_AVOID_VARIABLE_NAME =

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/ClassNameIdCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/ClassNameIdCheck.java
@@ -70,19 +70,22 @@ public class ClassNameIdCheck extends BaseCheck {
 				continue;
 			}
 
-			if (!_isAssignedInsideConstructor(variableDefDetailAST)) {
-				log(
-					variableDefDetailAST, _MSG_AVOID_VARIABLE_NAME,
-					variableName);
+			List<DetailAST> variableCallerDetailASTList =
+				getVariableCallerDetailASTList(variableDefDetailAST);
+
+			if (_isAssignedInsideConstructor(variableCallerDetailASTList) ||
+				_isInsideGetterAndSetter(
+					variableCallerDetailASTList, variableName)) {
+
+				continue;
 			}
+
+			log(variableDefDetailAST, _MSG_AVOID_VARIABLE_NAME, variableName);
 		}
 	}
 
 	private boolean _isAssignedInsideConstructor(
-		DetailAST variableDefDetailAST) {
-
-		List<DetailAST> variableCallerDetailASTList =
-			getVariableCallerDetailASTList(variableDefDetailAST);
+		List<DetailAST> variableCallerDetailASTList) {
 
 		for (DetailAST variableCallerDetailAST : variableCallerDetailASTList) {
 			if (hasParentWithTokenType(
@@ -93,6 +96,37 @@ public class ClassNameIdCheck extends BaseCheck {
 		}
 
 		return false;
+	}
+
+	private boolean _isInsideGetterAndSetter(
+		List<DetailAST> variableCallerDetailASTList, String variableName) {
+
+		String trimmedVariableName = variableName;
+
+		if (variableName.startsWith("_")) {
+			trimmedVariableName = variableName.substring(1);
+		}
+
+		for (DetailAST variableCallerDetailAST : variableCallerDetailASTList) {
+			DetailAST methodDefDetailAST = getParentWithTokenType(
+				variableCallerDetailAST, TokenTypes.METHOD_DEF);
+
+			if (methodDefDetailAST == null) {
+				continue;
+			}
+
+			String methodName = getName(methodDefDetailAST);
+
+			if (!StringUtil.equalsIgnoreCase(
+					methodName, "get" + trimmedVariableName) &&
+				!StringUtil.equalsIgnoreCase(
+					methodName, "set" + trimmedVariableName)) {
+
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	private static final String _MSG_AVOID_VARIABLE_NAME =

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/ClassNameIdCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/ClassNameIdCheck.java
@@ -117,11 +117,7 @@ public class ClassNameIdCheck extends BaseCheck {
 
 			String methodName = getName(methodDefDetailAST);
 
-			if (!StringUtil.equalsIgnoreCase(
-					methodName, "get" + trimmedVariableName) &&
-				!StringUtil.equalsIgnoreCase(
-					methodName, "set" + trimmedVariableName)) {
-
+			if (!methodName.matches("(?i)_?(get|set)" + trimmedVariableName)) {
 				return false;
 			}
 		}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/ClassNameIdCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/ClassNameIdCheck.java
@@ -1,0 +1,80 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.checkstyle.check;
+
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.source.formatter.check.util.JavaSourceUtil;
+
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+import java.util.List;
+
+/**
+ * @author Alan Huang
+ */
+public class ClassNameIdCheck extends BaseCheck {
+
+	@Override
+	public int[] getDefaultTokens() {
+		return new int[] {TokenTypes.CLASS_DEF};
+	}
+
+	@Override
+	protected void doVisitToken(DetailAST detailAST) {
+		String absolutePath = getAbsolutePath();
+
+		if (absolutePath.contains("/test/") ||
+			absolutePath.contains("/testIntegration/")) {
+
+			return;
+		}
+
+		String className = JavaSourceUtil.getClassName(absolutePath);
+
+		if (className.equals("ClassNameLocalServiceImpl") ||
+			className.equals("StagedModelType") ||
+			className.endsWith("Criterion") ||
+			className.endsWith("DisplayContext") ||
+			className.endsWith("ModelImpl") || className.endsWith("Tag")) {
+
+			return;
+		}
+
+		DetailAST parentDetailAST = detailAST.getParent();
+
+		if (parentDetailAST != null) {
+			return;
+		}
+
+		List<DetailAST> variableDefDetailASTList = getAllChildTokens(
+			detailAST.findFirstToken(TokenTypes.OBJBLOCK), false,
+			TokenTypes.VARIABLE_DEF);
+
+		for (DetailAST variableDefDetailAST : variableDefDetailASTList) {
+			if (!StringUtil.equalsIgnoreCase(
+					getTypeName(variableDefDetailAST, false, false, false),
+					"long")) {
+
+				continue;
+			}
+
+			String variableName = getName(variableDefDetailAST);
+
+			if (variableName.contains("ClassNameId") ||
+				variableName.contains("classNameId")) {
+
+				log(
+					variableDefDetailAST, _MSG_AVOID_VARIABLE_NAME,
+					variableName);
+			}
+		}
+	}
+
+	private static final String _MSG_AVOID_VARIABLE_NAME =
+		"variable.name.avoid";
+
+}

--- a/modules/util/source-formatter/src/main/resources/checkstyle.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle.xml
@@ -276,6 +276,11 @@
 			<message key="chaining.required" value="Chaining on ''{0}'' is preferred" />
 			<message key="response.unsorted" value="Method calls between ''Response.status'' and ''Response.build'' should be sorted" />
 		</module>
+		<module name="com.liferay.source.formatter.checkstyle.check.ClassNameIdCheck">
+			<property name="category" value="Bug Prevention" />
+			<property name="description" value="Avoid caching non-company scoped classNameIds." />
+			<message key="variable.name.avoid" value="Avoid using variable name ''{0}'', see LPD-29718" />
+		</module>
 		<module name="com.liferay.source.formatter.checkstyle.check.CompanyIterationCheck">
 			<property name="category" value="Bug Prevention" />
 			<property name="description" value="Checks that `CompanyLocalService.forEachCompany` or `CompanyLocalService.forEachCompanyId` is used when iterating over companies." />

--- a/modules/util/source-formatter/src/main/resources/checkstyle.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle.xml
@@ -279,6 +279,7 @@
 		<module name="com.liferay.source.formatter.checkstyle.check.ClassNameIdCheck">
 			<property name="category" value="Bug Prevention" />
 			<property name="description" value="Avoid caching non-company scoped classNameIds." />
+			<property name="enabled" value="false" />
 			<message key="variable.name.avoid" value="Avoid using variable name ''{0}'', see LPD-29718" />
 		</module>
 		<module name="com.liferay.source.formatter.checkstyle.check.CompanyIterationCheck">

--- a/modules/util/source-formatter/src/main/resources/documentation/all_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/all_checks.markdown
@@ -44,6 +44,7 @@ CSSImportsCheck | [Styling](styling_checks.markdown#styling-checks) | .css or .s
 CSSPropertiesOrderCheck | [Styling](styling_checks.markdown#styling-checks) | .css or .scss | Sorts properties in `.css` files. |
 [CamelCaseNameCheck](check/camel_case_name_check.markdown#camelcasenamecheck) | [Naming Conventions](naming_conventions_checks.markdown#naming-conventions-checks) | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Checks variable names for correct use of `CamelCase`. |
 ChainingCheck | [Styling](styling_checks.markdown#styling-checks) | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Checks that method chaining can be used when possible. |
+ClassNameIdCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .java | Avoid caching non-company scoped classNameIds. |
 [CodeownersFileLocationCheck](check/codeowners_file_location_check.markdown#codeownersfilelocationcheck) | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | CODEOWNERS | Checks that `CODEOWNERS` files are located in `.github` directory. |
 CodeownersWhitespaceCheck | [Styling](styling_checks.markdown#styling-checks) | CODEOWNERS | Finds missing and unnecessary whitespace in `CODEOWNERS` files. |
 [CompanyIterationCheck](check/company_iteration_check.markdown#companyiterationcheck) | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Checks that `CompanyLocalService.forEachCompany` or `CompanyLocalService.forEachCompanyId` is used when iterating over companies. |

--- a/modules/util/source-formatter/src/main/resources/documentation/bug_prevention_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/bug_prevention_checks.markdown
@@ -24,6 +24,7 @@ BNDBreakingChangeCommitMessageCheck | .bnd | Checks that commit message should c
 [BNDWebContextPathCheck](check/bnd_web_context_path_check.markdown#bndwebcontextpathcheck) | .bnd | Checks if the property value for `Web-ContextPath` matches the module directory. |
 CDNCheck | | Checks the URL in `artifact.properties` files. |
 CQLKeywordCheck | .cql | Checks that Cassandra keywords are upper case. |
+ClassNameIdCheck | .java | Avoid caching non-company scoped classNameIds. |
 [CodeownersFileLocationCheck](check/codeowners_file_location_check.markdown#codeownersfilelocationcheck) | CODEOWNERS | Checks that `CODEOWNERS` files are located in `.github` directory. |
 [CompanyIterationCheck](check/company_iteration_check.markdown#companyiterationcheck) | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Checks that `CompanyLocalService.forEachCompany` or `CompanyLocalService.forEachCompanyId` is used when iterating over companies. |
 CompatClassImportsCheck | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Checks that classes are imported from `compat` modules, when possible. |

--- a/modules/util/source-formatter/src/main/resources/documentation/java_source_processor_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/java_source_processor_checks.markdown
@@ -16,6 +16,7 @@ AssignAsUsedCheck | [Performance](performance_checks.markdown#performance-checks
 [AvoidStarImportCheck](https://checkstyle.sourceforge.io/checks/imports/avoidstarimport.html) | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Checks that there are no import statements that use the * notation. |
 [CamelCaseNameCheck](check/camel_case_name_check.markdown#camelcasenamecheck) | [Naming Conventions](naming_conventions_checks.markdown#naming-conventions-checks) | Checks variable names for correct use of `CamelCase`. |
 ChainingCheck | [Styling](styling_checks.markdown#styling-checks) | Checks that method chaining can be used when possible. |
+ClassNameIdCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Avoid caching non-company scoped classNameIds. |
 [CompanyIterationCheck](check/company_iteration_check.markdown#companyiterationcheck) | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Checks that `CompanyLocalService.forEachCompany` or `CompanyLocalService.forEachCompanyId` is used when iterating over companies. |
 CompatClassImportsCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Checks that classes are imported from `compat` modules, when possible. |
 ComponentAnnotationCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Performs several checks on classes with @Component annotation. |

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -206,6 +206,8 @@
         portal-kernel/src/com/liferay/portal/kernel/json/JSONArray.java,\
         portal-kernel/src/com/liferay/portal/kernel/json/JSONObject.java
 
+    checkstyle.ClassNameIdCheck.enabled=true
+
     checkstyle.CompanyIterationCheck.enabled=true
 
     checkstyle.ComponentExposureCheck.enabled=true


### PR DESCRIPTION
```
java.lang.Exception: Found 11 formatting issues:
1: Avoid using variable name '_classNameIds', see LPD-29718: /Users/alan/liferay_code/master/liferay-portal/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/exportimport/data/handler/helper/AssetVocabularySettingsImportHelper.java 163 (Checkstyle:ClassNameIdCheck)
2: Avoid using variable name '_previewClassNameId', see LPD-29718: /Users/alan/liferay_code/master/liferay-portal/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/processor/DefaultFragmentEntryProcessorContext.java 176 (Checkstyle:ClassNameIdCheck)
3: Avoid using variable name '_previewClassNameId', see LPD-29718: /Users/alan/liferay_code/master/liferay-portal/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/renderer/DefaultFragmentRendererContext.java 173 (Checkstyle:ClassNameIdCheck)
4: Avoid using variable name '_classNameId', see LPD-29718: /Users/alan/liferay_code/master/liferay-portal/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/FormStyledLayoutStructureItem.java 294 (Checkstyle:ClassNameIdCheck)
5: Avoid using variable name '_classNameId', see LPD-29718: /Users/alan/liferay_code/master/liferay-portal/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/helper/TranslationRequestHelper.java 242 (Checkstyle:ClassNameIdCheck)
6: Avoid using variable name '_classNameId', see LPD-29718: /Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/osb/osb-faro/osb-faro-engine-client/src/main/java/com/liferay/osb/faro/engine/client/model/DXPGroup.java 214 (Checkstyle:ClassNameIdCheck)
7: Avoid using variable name '_groupOrganizationClassNameIds', see LPD-29718: /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/service/persistence/impl/GroupFinderImpl.java 1593 (Checkstyle:ClassNameIdCheck)
8: Avoid using variable name '_classNameId', see LPD-29718: /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/asset/kernel/model/AssetEntryType.java 48 (Checkstyle:ClassNameIdCheck)
9: Avoid using variable name '_classNameIds', see LPD-29718: /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/asset/kernel/service/persistence/AssetEntryQuery.java 701 (Checkstyle:ClassNameIdCheck)
10: Avoid using variable name '_classNameId', see LPD-29718: /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/expando/kernel/model/BaseCustomAttributesDisplay.java 50 (Checkstyle:ClassNameIdCheck)
11: Avoid using variable name '_notificationClassNameId', see LPD-29718: /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/util/SubscriptionSender.java 1196 (Checkstyle:ClassNameIdCheck)

```