### PR TITLE
LPD-30242 Add IllegalHTMLTagsCheck

### DIFF
--- a/modules/apps/product-navigation/product-navigation-product-menu-api/src/main/java/com/liferay/product/navigation/product/menu/display/context/ProductMenuDisplayContext.java
+++ b/modules/apps/product-navigation/product-navigation-product-menu-api/src/main/java/com/liferay/product/navigation/product/menu/display/context/ProductMenuDisplayContext.java
@@ -72,9 +72,7 @@ public class ProductMenuDisplayContext {
 		Collections.reverse(applicationsMenuChildPanelCategories);
 
 		_childPanelCategories.addAll(
-			0,
-			_filterPanelCategories(
-				applicationsMenuChildPanelCategories));
+			0, _filterPanelCategories(applicationsMenuChildPanelCategories));
 
 		return _childPanelCategories;
 	}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/IllegalHTMLTagsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/IllegalHTMLTagsCheck.java
@@ -1,0 +1,66 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.check;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.tools.ToolsUtil;
+
+import java.util.List;
+
+/**
+ * @author Alan Huang
+ */
+public class IllegalHTMLTagsCheck extends BaseFileCheck {
+
+	@Override
+	public boolean isLiferaySourceCheck() {
+		return true;
+	}
+
+	@Override
+	protected String doProcess(
+		String fileName, String absolutePath, String content) {
+
+		List<String> avoidHtmlHeaderNames = getAttributeValues(
+			_AVOID_HTML_HEADER_NAMES_KEY, absolutePath);
+
+		for (String avoidHtmlHeaderName : avoidHtmlHeaderNames) {
+			int x = -1;
+
+			while (true) {
+				x = StringUtil.indexOfAny(
+					content,
+					new String[] {
+						"<" + avoidHtmlHeaderName + " ",
+						"<" + avoidHtmlHeaderName + ">"
+					},
+					x + 1);
+
+				if (x == -1) {
+					break;
+				}
+
+				if (ToolsUtil.isInsideQuotes(content, x)) {
+					continue;
+				}
+
+				addMessage(
+					fileName,
+					StringBundler.concat(
+						"Do not use '", avoidHtmlHeaderName,
+						"', use 'div' instead"),
+					getLineNumber(content, x));
+			}
+		}
+
+		return content;
+	}
+
+	private static final String _AVOID_HTML_HEADER_NAMES_KEY =
+		"avoidHtmlHeaderNames";
+
+}

--- a/modules/util/source-formatter/src/main/resources/documentation/all_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/all_checks.markdown
@@ -118,6 +118,7 @@ GroovyImportsCheck | [Styling](styling_checks.markdown#styling-checks) | .groovy
 HTMLEmptyLinesCheck | [Styling](styling_checks.markdown#styling-checks) | .html or .path | Finds missing and unnecessary empty lines. |
 HTMLWhitespaceCheck | [Styling](styling_checks.markdown#styling-checks) | .html or .path | Finds missing and unnecessary whitespace in `.html` files. |
 [IfStatementCheck](check/if_statement_check.markdown#ifstatementcheck) | [Styling](styling_checks.markdown#styling-checks) | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Finds empty if-statements and consecutive if-statements with identical bodies. |
+IllegalHTMLTagsCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .ftl, .html, .jsp, .jspf, .jspx, .path, .tag, .tpl or .vm | Finds cases of incorrect use of HTML tags. |
 IllegalImportsCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Finds cases of incorrect use of certain classes. |
 IllegalTaglibsCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .ftl, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Finds cases of incorrect use of certain deprecated taglibs in modules. |
 [IncorrectFileLocationCheck](check/incorrect_file_location_check.markdown#incorrectfilelocationcheck) | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | | Checks that `/src/*/java/` only contains `.java` files. |

--- a/modules/util/source-formatter/src/main/resources/documentation/all_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/all_checks.markdown
@@ -118,7 +118,7 @@ GroovyImportsCheck | [Styling](styling_checks.markdown#styling-checks) | .groovy
 HTMLEmptyLinesCheck | [Styling](styling_checks.markdown#styling-checks) | .html or .path | Finds missing and unnecessary empty lines. |
 HTMLWhitespaceCheck | [Styling](styling_checks.markdown#styling-checks) | .html or .path | Finds missing and unnecessary whitespace in `.html` files. |
 [IfStatementCheck](check/if_statement_check.markdown#ifstatementcheck) | [Styling](styling_checks.markdown#styling-checks) | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Finds empty if-statements and consecutive if-statements with identical bodies. |
-IllegalHTMLTagsCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .ftl, .html, .jsp, .jspf, .jspx, .path, .tag, .tpl or .vm | Finds cases of incorrect use of HTML tags. |
+IllegalHTMLTagsCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .ftl, .html, .js, .jsp, .jspf, .jspx, .jsx, .path, .tag, .tpl or .vm | Finds cases of incorrect use of HTML tags. |
 IllegalImportsCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Finds cases of incorrect use of certain classes. |
 IllegalTaglibsCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .ftl, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Finds cases of incorrect use of certain deprecated taglibs in modules. |
 [IncorrectFileLocationCheck](check/incorrect_file_location_check.markdown#incorrectfilelocationcheck) | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | | Checks that `/src/*/java/` only contains `.java` files. |

--- a/modules/util/source-formatter/src/main/resources/documentation/bug_prevention_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/bug_prevention_checks.markdown
@@ -54,6 +54,7 @@ GradleProvidedDependenciesCheck | .gradle | Validates the scope of dependencies 
 GradleRestClientDependenciesCheck | .gradle | Validates the project dependencies `.*-rest-client` can only be used for `testIntegrationImplementation`. |
 GradleTestDependencyVersionCheck | .gradle | Checks the version for dependencies in gradle build files. |
 GradleTestUtilDeployDirCheck | .gradle | Checks for incorrect use of `deployDir`. |
+IllegalHTMLTagsCheck | .ftl, .html, .jsp, .jspf, .jspx, .path, .tag, .tpl or .vm | Finds cases of incorrect use of HTML tags. |
 IllegalImportsCheck | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Finds cases of incorrect use of certain classes. |
 IllegalTaglibsCheck | .ftl, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Finds cases of incorrect use of certain deprecated taglibs in modules. |
 [IncorrectFileLocationCheck](check/incorrect_file_location_check.markdown#incorrectfilelocationcheck) | | Checks that `/src/*/java/` only contains `.java` files. |

--- a/modules/util/source-formatter/src/main/resources/documentation/bug_prevention_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/bug_prevention_checks.markdown
@@ -54,7 +54,7 @@ GradleProvidedDependenciesCheck | .gradle | Validates the scope of dependencies 
 GradleRestClientDependenciesCheck | .gradle | Validates the project dependencies `.*-rest-client` can only be used for `testIntegrationImplementation`. |
 GradleTestDependencyVersionCheck | .gradle | Checks the version for dependencies in gradle build files. |
 GradleTestUtilDeployDirCheck | .gradle | Checks for incorrect use of `deployDir`. |
-IllegalHTMLTagsCheck | .ftl, .html, .jsp, .jspf, .jspx, .path, .tag, .tpl or .vm | Finds cases of incorrect use of HTML tags. |
+IllegalHTMLTagsCheck | .ftl, .html, .js, .jsp, .jspf, .jspx, .jsx, .path, .tag, .tpl or .vm | Finds cases of incorrect use of HTML tags. |
 IllegalImportsCheck | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Finds cases of incorrect use of certain classes. |
 IllegalTaglibsCheck | .ftl, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Finds cases of incorrect use of certain deprecated taglibs in modules. |
 [IncorrectFileLocationCheck](check/incorrect_file_location_check.markdown#incorrectfilelocationcheck) | | Checks that `/src/*/java/` only contains `.java` files. |

--- a/modules/util/source-formatter/src/main/resources/documentation/ftl_source_processor_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/ftl_source_processor_checks.markdown
@@ -11,4 +11,5 @@ FTLStylingCheck | [Styling](styling_checks.markdown#styling-checks) | Applies ru
 FTLTagAttributesCheck | [Styling](styling_checks.markdown#styling-checks) | Sorts and formats attributes values in tags. |
 FTLTagCheck | [Styling](styling_checks.markdown#styling-checks) | Finds cases where consecutive `#assign` can be combined. |
 FTLWhitespaceCheck | [Styling](styling_checks.markdown#styling-checks) | Finds missing and unnecessary whitespace in `.ftl` files. |
+IllegalHTMLTagsCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Finds cases of incorrect use of HTML tags. |
 IllegalTaglibsCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Finds cases of incorrect use of certain deprecated taglibs in modules. |

--- a/modules/util/source-formatter/src/main/resources/documentation/html_source_processor_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/html_source_processor_checks.markdown
@@ -4,4 +4,5 @@ Check | Category | Description
 ----- | -------- | -----------
 HTMLEmptyLinesCheck | [Styling](styling_checks.markdown#styling-checks) | Finds missing and unnecessary empty lines. |
 HTMLWhitespaceCheck | [Styling](styling_checks.markdown#styling-checks) | Finds missing and unnecessary whitespace in `.html` files. |
+IllegalHTMLTagsCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Finds cases of incorrect use of HTML tags. |
 XMLTagAttributesCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Performs several checks on tag attributes. |

--- a/modules/util/source-formatter/src/main/resources/documentation/js_source_processor_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/js_source_processor_checks.markdown
@@ -2,6 +2,7 @@
 
 Check | Category | Description
 ----- | -------- | -----------
+IllegalHTMLTagsCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Finds cases of incorrect use of HTML tags. |
 [JSLodashDependencyCheck](check/js_lodash_dependency_check.markdown#jslodashdependencycheck) | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Finds incorrect use of `AUI._`. |
 JSStylingCheck | [Styling](styling_checks.markdown#styling-checks) | Applies rules to enforce consistency in code style. |
 JSWhitespaceCheck | [Styling](styling_checks.markdown#styling-checks) | Finds missing and unnecessary whitespace in `.js` files. |

--- a/modules/util/source-formatter/src/main/resources/documentation/jsp_source_processor_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/jsp_source_processor_checks.markdown
@@ -21,6 +21,7 @@ FactoryCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-ch
 [GenericTypeCheck](check/generic_type_check.markdown#generictypecheck) | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Checks that generics are always specified to provide compile-time checking and removing the risk of `ClassCastException` during runtime. |
 [GetterUtilCheck](check/getter_util_check.markdown#getterutilcheck) | [Styling](styling_checks.markdown#styling-checks) | Finds cases where the default value is passed to `GetterUtil.get*` or `ParamUtil.get*`. |
 [IfStatementCheck](check/if_statement_check.markdown#ifstatementcheck) | [Styling](styling_checks.markdown#styling-checks) | Finds empty if-statements and consecutive if-statements with identical bodies. |
+IllegalHTMLTagsCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Finds cases of incorrect use of HTML tags. |
 IllegalImportsCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Finds cases of incorrect use of certain classes. |
 IllegalTaglibsCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Finds cases of incorrect use of certain deprecated taglibs in modules. |
 InstanceofOrderCheck | [Styling](styling_checks.markdown#styling-checks) | Check the order of `instanceof` calls. |

--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -1335,6 +1335,10 @@
 
 		<!-- Liferay Source Checks -->
 
+		<check name="IllegalHTMLTagsCheck">
+			<category name="Bug Prevention" />
+			<description name="Finds cases of incorrect use of HTML tags." />
+		</check>
 		<check name="LanguageKeysCheck">
 			<category name="Bug Prevention" />
 			<description name="Finds missing language keys in `Language.properties`." />

--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -241,6 +241,10 @@
 			<category name="Styling" />
 			<description name="Finds missing and unnecessary whitespace in `.ftl` files." />
 		</check>
+		<check name="IllegalHTMLTagsCheck">
+			<category name="Bug Prevention" />
+			<description name="Finds cases of incorrect use of HTML tags." />
+		</check>
 		<check name="IllegalTaglibsCheck">
 			<category name="Bug Prevention" />
 			<description name="Finds cases of incorrect use of certain deprecated taglibs in modules." />
@@ -373,6 +377,10 @@
 		<check name="HTMLWhitespaceCheck">
 			<category name="Styling" />
 			<description name="Finds missing and unnecessary whitespace in `.html` files." />
+		</check>
+		<check name="IllegalHTMLTagsCheck">
+			<category name="Bug Prevention" />
+			<description name="Finds cases of incorrect use of HTML tags." />
 		</check>
 		<check name="XMLTagAttributesCheck">
 			<category name="Bug Prevention" />
@@ -1225,6 +1233,10 @@
 		<check name="CopyrightCheck">
 			<category name="Styling" />
 			<description name="Validates `copyright` header." />
+		</check>
+		<check name="IllegalHTMLTagsCheck">
+			<category name="Bug Prevention" />
+			<description name="Finds cases of incorrect use of HTML tags." />
 		</check>
 		<check name="JSPCoreTaglibCheck">
 			<category name="Styling" />

--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -244,6 +244,7 @@
 		<check name="IllegalHTMLTagsCheck">
 			<category name="Bug Prevention" />
 			<description name="Finds cases of incorrect use of HTML tags." />
+			<property name="enabled" value="false" />
 		</check>
 		<check name="IllegalTaglibsCheck">
 			<category name="Bug Prevention" />
@@ -381,6 +382,7 @@
 		<check name="IllegalHTMLTagsCheck">
 			<category name="Bug Prevention" />
 			<description name="Finds cases of incorrect use of HTML tags." />
+			<property name="enabled" value="false" />
 		</check>
 		<check name="XMLTagAttributesCheck">
 			<category name="Bug Prevention" />
@@ -1237,6 +1239,7 @@
 		<check name="IllegalHTMLTagsCheck">
 			<category name="Bug Prevention" />
 			<description name="Finds cases of incorrect use of HTML tags." />
+			<property name="enabled" value="false" />
 		</check>
 		<check name="JSPCoreTaglibCheck">
 			<category name="Styling" />
@@ -1338,6 +1341,7 @@
 		<check name="IllegalHTMLTagsCheck">
 			<category name="Bug Prevention" />
 			<description name="Finds cases of incorrect use of HTML tags." />
+			<property name="enabled" value="false" />
 		</check>
 		<check name="LanguageKeysCheck">
 			<category name="Bug Prevention" />

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -752,6 +752,8 @@
         h5,\
         h6
 
+    source.check.IllegalHTMLTagsCheck.enabled=true
+
     source.check.IllegalImportsCheck.allowedOptionalFileNames=\
         modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/resource/OpenAPIResourceImpl.java,\
         modules/apps/push-notifications/push-notifications-sender/push-notifications-sender-apple/src/main/java/com/liferay/push/notifications/sender/apple/internal/ApplePushNotificationsSender.java,\

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -747,6 +747,11 @@
 
     source.check.IfStatementCheck.enabled=true
 
+    source.check.IllegalHTMLTagsCheck.avoidHtmlHeaderNames=\
+        h4,\
+        h5,\
+        h6
+
     source.check.IllegalImportsCheck.allowedOptionalFileNames=\
         modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/resource/OpenAPIResourceImpl.java,\
         modules/apps/push-notifications/push-notifications-sender/push-notifications-sender-apple/src/main/java/com/liferay/push/notifications/sender/apple/internal/ApplePushNotificationsSender.java,\


### PR DESCRIPTION
```
     [java] java.lang.Exception: Found 68 formatting issues:
     [java] 1: Do not use 'h4', use 'div' instead: ./modules/apps/commerce/commerce-service/src/main/resources/com/liferay/commerce/internal/notification/term/evaluator/dependencies/commerce_order_order_items.ftl 65 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 2: Do not use 'h4', use 'div' instead: ./modules/apps/site-initializer/site-initializer-liferay-marketplace/src/main/resources/site-initializer/fragments/group/marketplace-base-fragments/fragments/faq/index.html 3 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 3: Do not use 'h5', use 'div' instead: ./modules/apps/site-initializer/site-initializer-liferaybotics/src/main/resources/site-initializer/fragments/kb-collection/fragments/service-card/index.html 5 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 4: Do not use 'h5', use 'div' instead: ./modules/apps/site-initializer/site-initializer-masterclass/src/main/resources/site-initializer/fragments/group/masterclass/fragments/masterclass-classroom-header/index.html 19 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 5: Do not use 'h6', use 'div' instead: ./modules/apps/site-initializer/site-initializer-raylife-ap/src/main/resources/site-initializer/fragments/group/src/raylife-ap-fragments/fragments/fake-content/index.html 3 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 6: Do not use 'h4', use 'div' instead: ./modules/apps/site-initializer/site-initializer-raylife-ap/src/main/resources/site-initializer/fragments/group/src/raylife-ap-fragments/fragments/layout/index.html 65 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 7: Do not use 'h4', use 'div' instead: ./modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/fragments/group/raylife/fragments/claim-steps/index.html 1 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 8: Do not use 'h4', use 'div' instead: ./modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/fragments/group/raylife/fragments/congrats/index.html 15 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 9: Do not use 'h4', use 'div' instead: ./modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/fragments/group/raylife/fragments/get-in-touch/index.html 60 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 10: Do not use 'h4', use 'div' instead: ./modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/fragments/group/raylife/fragments/insurance-faq/index.html 3 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 11: Do not use 'h4', use 'div' instead: ./modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/fragments/group/raylife/fragments/policy-content/index.html 13 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 12: Do not use 'h4', use 'div' instead: ./modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/fragments/group/raylife/fragments/policy-content/index.html 40 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 13: Do not use 'h4', use 'div' instead: ./modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/fragments/group/raylife/fragments/policy-content/index.html 83 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 14: Do not use 'h4', use 'div' instead: ./modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/fragments/group/raylife/fragments/policy-content/index.html 110 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 15: Do not use 'h4', use 'div' instead: ./modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/fragments/group/raylife/fragments/policy-content/index.html 115 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 16: Do not use 'h4', use 'div' instead: ./modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/fragments/group/raylife/fragments/policy-content/index.html 121 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 17: Do not use 'h4', use 'div' instead: ./modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/fragments/group/raylife/fragments/product-content/index.html 13 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 18: Do not use 'h4', use 'div' instead: ./modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/fragments/group/raylife/fragments/product-content/index.html 20 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 19: Do not use 'h4', use 'div' instead: ./modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/fragments/group/raylife/fragments/product-content/index.html 26 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 20: Do not use 'h4', use 'div' instead: ./modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/fragments/group/raylife/fragments/product-content/index.html 32 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 21: Do not use 'h4', use 'div' instead: ./modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/fragments/group/raylife/fragments/product-resources/index.html 2 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 22: Do not use 'h4', use 'div' instead: ./modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/fragments/group/raylife/fragments/products-list/index.html 11 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 23: Do not use 'h4', use 'div' instead: ./modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/fragments/group/raylife/fragments/public-footer/index.html 9 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 24: Do not use 'h4', use 'div' instead: ./modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/fragments/group/raylife/fragments/public-footer/index.html 36 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 25: Do not use 'h4', use 'div' instead: ./modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/fragments/group/raylife/fragments/public-footer/index.html 52 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 26: Do not use 'h4', use 'div' instead: ./modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/fragments/group/raylife/fragments/public-footer/index.html 68 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 27: Do not use 'h6', use 'div' instead: ./modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/fragments/group/raylife/fragments/quote-footer/index.html 4 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 28: Do not use 'h5', use 'div' instead: ./modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/fragments/group/raylife/fragments/quote-footer/index.html 8 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 29: Do not use 'h5', use 'div' instead: ./modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/fragments/group/raylife/fragments/section-video/index.html 10 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 30: Do not use 'h4', use 'div' instead: ./modules/apps/site-initializer/site-initializer-team-extranet/src/main/resources/site-initializer/fragments/group/components/fragments/entry-card/index.html 8 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 31: Do not use 'h4', use 'div' instead: ./modules/apps/site-initializer/site-initializer-team-extranet/src/main/resources/site-initializer/fragments/group/components/fragments/member-card/index.html 5 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 32: Do not use 'h4', use 'div' instead: ./modules/apps/site-initializer/site-initializer-team-extranet/src/main/resources/site-initializer/fragments/group/components/fragments/member-card/index.html 10 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 33: Do not use 'h6', use 'div' instead: ./modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/src/main/resources/site-initializer/fragments/group/src/customer-portal/fragments/footer/index.html 3 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 34: Do not use 'h6', use 'div' instead: ./modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/src/main/resources/site-initializer/fragments/group/src/customer-portal/fragments/footer/index.html 7 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 35: Do not use 'h5', use 'div' instead: ./modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-evp/src/main/resources/site-initializer/fragments/group/evp/fragments/evp-process-steps-slider/index.html 28 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 36: Do not use 'h4', use 'div' instead: ./modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-evp/src/main/resources/site-initializer/fragments/group/evp/fragments/evp-process-steps-slider/index.html 32 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 37: Do not use 'h4', use 'div' instead: ./modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/RebaseErrorTopLevelBuildTemplate.html 7 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 38: Do not use 'h4', use 'div' instead: ./modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/RebaseErrorTopLevelBuildTemplate.html 16 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 39: Do not use 'h5', use 'div' instead: ./modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/RebaseErrorTopLevelBuildTemplate.html 31 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 40: Do not use 'h4', use 'div' instead: ./modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/RebaseErrorTopLevelBuildTemplate.html 35 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 41: Do not use 'h5', use 'div' instead: ./modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/RebaseErrorTopLevelBuildTemplate.html 40 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 42: Do not use 'h6', use 'div' instead: ./modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/RebaseErrorTopLevelBuildTemplate.html 43 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 43: Do not use 'h4', use 'div' instead: ./modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/RebaseErrorTopLevelBuildTemplate.html 63 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 44: Do not use 'h4', use 'div' instead: ./modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/aggregate-report/index.html 16 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 45: Do not use 'h4', use 'div' instead: ./modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/aggregate-report/index.html 58 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 46: Do not use 'h4', use 'div' instead: ./modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/aggregate-report/index.html 64 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 47: Do not use 'h4', use 'div' instead: ./modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/utilization-report/index.html 12 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 48: Do not use 'h4', use 'div' instead: ./modules/test/jenkins-results-parser/src/main/resources/com/liferay/jenkins/results/parser/dependencies/metrics/utilization-report/index.html 20 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 49: Do not use 'h4', use 'div' instead: ./workspaces/liferay-learn-workspace/client-extensions/liferay-learn-site-initializer/site-initializer/ddm-templates/learn-article/ddm-template.ftl 96 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 50: Do not use 'h5', use 'div' instead: ./workspaces/liferay-partner-workspace/client-extensions/liferay-partner-site-initializer/site-initializer/fragments/group/src/mdf-claim-detail-collection/fragments/claim-detail-activity-list/index.html 17 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 51: Do not use 'h5', use 'div' instead: ./workspaces/liferay-partner-workspace/client-extensions/liferay-partner-site-initializer/site-initializer/fragments/group/src/mdf-claim-detail-collection/fragments/claim-detail-activity-list/index.html 20 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 52: Do not use 'h6', use 'div' instead: ./workspaces/liferay-partner-workspace/client-extensions/liferay-partner-site-initializer/site-initializer/fragments/group/src/mdf-claim-detail-collection/fragments/claim-detail-activity-list/index.html 40 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 53: Do not use 'h6', use 'div' instead: ./workspaces/liferay-partner-workspace/client-extensions/liferay-partner-site-initializer/site-initializer/fragments/group/src/mdf-claim-detail-collection/fragments/claim-detail-activity-list/index.html 59 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 54: Do not use 'h6', use 'div' instead: ./workspaces/liferay-partner-workspace/client-extensions/liferay-partner-site-initializer/site-initializer/fragments/group/src/mdf-claim-detail-collection/fragments/claim-detail-activity-list/index.html 71 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 55: Do not use 'h6', use 'div' instead: ./workspaces/liferay-partner-workspace/client-extensions/liferay-partner-site-initializer/site-initializer/fragments/group/src/mdf-claim-detail-collection/fragments/claim-detail-activity-list/index.html 89 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 56: Do not use 'h6', use 'div' instead: ./workspaces/liferay-partner-workspace/client-extensions/liferay-partner-site-initializer/site-initializer/fragments/group/src/mdf-claim-detail-collection/fragments/claim-detail-activity-list/index.html 101 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 57: Do not use 'h6', use 'div' instead: ./workspaces/liferay-partner-workspace/client-extensions/liferay-partner-site-initializer/site-initializer/fragments/group/src/mdf-claim-detail-collection/fragments/claim-detail-activity-list/index.html 116 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 58: Do not use 'h6', use 'div' instead: ./workspaces/liferay-partner-workspace/client-extensions/liferay-partner-site-initializer/site-initializer/fragments/group/src/mdf-claim-detail-collection/fragments/claim-detail-activity-list/index.html 161 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 59: Do not use 'h5', use 'div' instead: ./workspaces/liferay-partner-workspace/client-extensions/liferay-partner-site-initializer/site-initializer/fragments/group/src/mdf-claim-detail-collection/fragments/claim-detail-document-list/index.html 16 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 60: Do not use 'h4', use 'div' instead: ./workspaces/liferay-partner-workspace/client-extensions/liferay-partner-site-initializer/site-initializer/fragments/group/src/mdf-request-detail-collection/fragments/activities-list-panel/index.html 197 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 61: Do not use 'h6', use 'div' instead: ./workspaces/liferay-partner-workspace/client-extensions/liferay-partner-site-initializer/site-initializer/fragments/group/src/mdf-request-detail-collection/fragments/claims-list-on-mdf-request-detail/index.html 125 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 62: Do not use 'h6', use 'div' instead: ./workspaces/liferay-partner-workspace/client-extensions/liferay-partner-site-initializer/site-initializer/fragments/group/src/mdf-request-detail-collection/fragments/claims-list-on-mdf-request-detail/index.html 130 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 63: Do not use 'h6', use 'div' instead: ./workspaces/liferay-partner-workspace/client-extensions/liferay-partner-site-initializer/site-initializer/fragments/group/src/mdf-request-detail-collection/fragments/claims-list-on-mdf-request-detail/index.html 134 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 64: Do not use 'h4', use 'div' instead: ./workspaces/liferay-partner-workspace/client-extensions/liferay-partner-site-initializer/site-initializer/fragments/group/src/partner-portal/fragments/announcements-subscribe/index.html 2 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 65: Do not use 'h5', use 'div' instead: ./workspaces/liferay-tryitnow-workspace/client-extensions/liferay-tryitnow-site-initializer/site-initializer/fragments/group/tryitnow-custom-fragments/fragments/tryitnow-faq/index.html 5 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 66: Do not use 'h5', use 'div' instead: ./workspaces/liferay-tryitnow-workspace/client-extensions/liferay-tryitnow-site-initializer/site-initializer/fragments/group/tryitnow-custom-fragments/fragments/tryitnow-signin-login-helper/index.html 21 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 67: Do not use 'h4', use 'div' instead: ./workspaces/liferay-tryitnow-workspace/client-extensions/liferay-tryitnow-site-initializer/site-initializer/fragments/group/tryitnow-custom-fragments/fragments/tryitnow-trial-guide-accordion/index.html 13 (SourceCheck:IllegalHTMLTagsCheck)
     [java] 68: Do not use 'h5', use 'div' instead: ./workspaces/liferay-tryitnow-workspace/client-extensions/liferay-tryitnow-site-initializer/site-initializer/fragments/group/tryitnow-custom-fragments/fragments/tryitnow-trial-guide-login-helper/index.html 21 (SourceCheck:IllegalHTMLTagsCheck)

```