### PR TITLE
LPD-33240 Add ArrayUtilCheck

### DIFF
--- a/modules/apps/document-library/document-library-taglib-test/src/testIntegration/java/com/liferay/document/library/taglib/servlet/taglib/test/RepositoryBrowserTagTest.java
+++ b/modules/apps/document-library/document-library-taglib-test/src/testIntegration/java/com/liferay/document/library/taglib/servlet/taglib/test/RepositoryBrowserTagTest.java
@@ -75,6 +75,53 @@ public class RepositoryBrowserTagTest {
 		_testViewableByGuest("true", repositoryBrowserTag);
 	}
 
+	private MockHttpServletRequest _getMockHttpServletRequest()
+		throws PortalException {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		String portletName = RandomTestUtil.randomString();
+
+		String attributeName = StringBundler.concat(
+			portletName, StringPool.DASH, WebKeys.CURRENT_PORTLET_URL);
+
+		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
+			new MockLiferayPortletRenderRequest() {
+
+				@Override
+				public String getPortletName() {
+					return portletName;
+				}
+
+			};
+
+		mockLiferayPortletRenderRequest.setAttribute(
+			attributeName, new MockLiferayPortletURL());
+
+		mockHttpServletRequest.setAttribute(
+			JavaConstants.JAVAX_PORTLET_REQUEST,
+			mockLiferayPortletRenderRequest);
+
+		mockHttpServletRequest.setAttribute(
+			JavaConstants.JAVAX_PORTLET_RESPONSE,
+			new MockLiferayPortletActionResponse());
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay());
+
+		return mockHttpServletRequest;
+	}
+
+	private ThemeDisplay _getThemeDisplay() throws PortalException {
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser()));
+		themeDisplay.setScopeGroupId(_group.getGroupId());
+
+		return themeDisplay;
+	}
+
 	private void _testViewableByGuest(
 			String expectedViewableByGuestValue,
 			RepositoryBrowserTag repositoryBrowserTag)
@@ -129,53 +176,6 @@ public class RepositoryBrowserTagTest {
 		Assert.assertEquals(
 			expectedViewableByGuestValue,
 			repositoryBrowserComponentContext.get("viewableByGuest"));
-	}
-
-	private MockHttpServletRequest _getMockHttpServletRequest()
-		throws PortalException {
-
-		MockHttpServletRequest mockHttpServletRequest =
-			new MockHttpServletRequest();
-
-		String portletName = RandomTestUtil.randomString();
-
-		String attributeName = StringBundler.concat(
-			portletName, StringPool.DASH, WebKeys.CURRENT_PORTLET_URL);
-
-		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
-			new MockLiferayPortletRenderRequest() {
-
-				@Override
-				public String getPortletName() {
-					return portletName;
-				}
-
-			};
-
-		mockLiferayPortletRenderRequest.setAttribute(
-			attributeName, new MockLiferayPortletURL());
-
-		mockHttpServletRequest.setAttribute(
-			JavaConstants.JAVAX_PORTLET_REQUEST,
-			mockLiferayPortletRenderRequest);
-
-		mockHttpServletRequest.setAttribute(
-			JavaConstants.JAVAX_PORTLET_RESPONSE,
-			new MockLiferayPortletActionResponse());
-		mockHttpServletRequest.setAttribute(
-			WebKeys.THEME_DISPLAY, _getThemeDisplay());
-
-		return mockHttpServletRequest;
-	}
-
-	private ThemeDisplay _getThemeDisplay() throws PortalException {
-		ThemeDisplay themeDisplay = new ThemeDisplay();
-
-		themeDisplay.setPermissionChecker(
-			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser()));
-		themeDisplay.setScopeGroupId(_group.getGroupId());
-
-		return themeDisplay;
 	}
 
 	@DeleteAfterTestRun

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/OIDCUserInfoProcessor.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/OIDCUserInfoProcessor.java
@@ -289,7 +289,7 @@ public class OIDCUserInfoProcessor {
 			companyId, userInfoJSONObject,
 			userInfoMapperJSONObject.getJSONObject("users_roles"));
 
-		if ((roleIds == null) || (roleIds.length == 0)) {
+		if (ArrayUtil.isEmpty(roleIds)) {
 			roleIds = _getRoleIds(companyId, issuer);
 		}
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/ArrayUtilCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/ArrayUtilCheck.java
@@ -1,0 +1,105 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.checkstyle.check;
+
+import com.liferay.portal.kernel.util.StringUtil;
+
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * @author Alan Huang
+ */
+public class ArrayUtilCheck extends BaseCheck {
+
+	@Override
+	public int[] getDefaultTokens() {
+		return new int[] {TokenTypes.EQUAL};
+	}
+
+	@Override
+	protected void doVisitToken(DetailAST detailAST) {
+		if (isExcludedPath(RUN_OUTSIDE_PORTAL_EXCLUDES)) {
+			return;
+		}
+
+		_checkArrayLengthIsZero(detailAST);
+	}
+
+	private void _checkArrayEqualsNullAssertion(
+		DetailAST detailAST, String variableName) {
+
+		DetailAST previousSiblingDetailAST = detailAST.getPreviousSibling();
+
+		if ((previousSiblingDetailAST == null) ||
+			(previousSiblingDetailAST.getType() != TokenTypes.LPAREN)) {
+
+			return;
+		}
+
+		DetailAST identDetailAST = detailAST.getFirstChild();
+
+		if ((identDetailAST == null) ||
+			(identDetailAST.getType() != TokenTypes.IDENT) ||
+			!Objects.equals(identDetailAST.getText(), variableName)) {
+
+			return;
+		}
+
+		DetailAST nextSiblingDetailAST = identDetailAST.getNextSibling();
+
+		if (nextSiblingDetailAST.getType() != TokenTypes.LITERAL_NULL) {
+			return;
+		}
+
+		log(detailAST.getParent(), _MSG_USE_ARRAY_UTIL_IS_EMPTY, variableName);
+	}
+
+	private void _checkArrayLengthIsZero(DetailAST detailAST) {
+		DetailAST firstChildDetailAST = detailAST.getFirstChild();
+
+		if ((firstChildDetailAST == null) ||
+			(firstChildDetailAST.getType() != TokenTypes.DOT)) {
+
+			return;
+		}
+
+		List<String> names = getNames(firstChildDetailAST, false);
+
+		if ((names.size() != 2) || !StringUtil.equals(names.get(1), "length")) {
+			return;
+		}
+
+		DetailAST nextSiblingDetailAST = firstChildDetailAST.getNextSibling();
+
+		if ((nextSiblingDetailAST == null) ||
+			(nextSiblingDetailAST.getType() != TokenTypes.NUM_INT) ||
+			!StringUtil.equals(nextSiblingDetailAST.getText(), "0")) {
+
+			return;
+		}
+
+		DetailAST parentDetailAST = detailAST.getParent();
+
+		if (parentDetailAST.getType() != TokenTypes.LOR) {
+			return;
+		}
+
+		DetailAST equalDetailAST = parentDetailAST.findFirstToken(
+			TokenTypes.EQUAL);
+
+		if (!equals(equalDetailAST, detailAST)) {
+			_checkArrayEqualsNullAssertion(equalDetailAST, names.get(0));
+		}
+	}
+
+	private static final String _MSG_USE_ARRAY_UTIL_IS_EMPTY =
+		"array.util.is.empty.use";
+
+}

--- a/modules/util/source-formatter/src/main/resources/checkstyle-jsp.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle-jsp.xml
@@ -178,6 +178,12 @@
 			<message key="start.character.invalid" value="When appending multiple literal strings, only the first literal string can start with ''{0}''" />
 			<message key="string.combine" value="Combine the literal string ''{0}'' with ''{1}''" />
 		</module>
+		<module name="com.liferay.source.formatter.checkstyle.check.ArrayUtilCheck">
+			<property name="category" value="Styling" />
+			<property name="description" value="Checks for utilization of class `ArrayUtil`." />
+			<property name="enabled" value="false" />
+			<message key="array.util.is.empty.use" value="Use ''ArrayUtil.isEmpty({0})'' to simplify code" />
+		</module>
 		<module name="com.liferay.source.formatter.checkstyle.check.CamelCaseNameCheck">
 			<property name="category" value="Naming Conventions" />
 			<property name="description" value="Checks variable names for correct use of `CamelCase`." />

--- a/modules/util/source-formatter/src/main/resources/checkstyle.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle.xml
@@ -239,6 +239,11 @@
 			<property name="description" value="Checks for correct use of `com.liferay.arquillian.extension.junit.bridge.junit.Arquillian`." />
 			<message key="import.invalid" value="Use import ''com.liferay.arquillian.extension.junit.bridge.junit.Arquillian'' instead of ''org.jboss.arquillian.junit.Arquillian'', see LPS-68945" />
 		</module>
+		<module name="com.liferay.source.formatter.checkstyle.check.ArrayUtilCheck">
+			<property name="category" value="Styling" />
+			<property name="description" value="Checks for utilization of class `ArrayUtil`." />
+			<message key="array.util.is.empty.use" value="Use ''ArrayUtil.isEmpty({0})'' to simplify code" />
+		</module>
 		<module name="com.liferay.source.formatter.checkstyle.check.AssertEqualsCheck">
 			<property name="category" value="Styling" />
 			<property name="description" value="Checks that additional information is provided when calling `Assert.assertEquals`." />

--- a/modules/util/source-formatter/src/main/resources/checkstyle.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle.xml
@@ -242,6 +242,7 @@
 		<module name="com.liferay.source.formatter.checkstyle.check.ArrayUtilCheck">
 			<property name="category" value="Styling" />
 			<property name="description" value="Checks for utilization of class `ArrayUtil`." />
+			<property name="enabled" value="false" />
 			<message key="array.util.is.empty.use" value="Use ''ArrayUtil.isEmpty({0})'' to simplify code" />
 		</module>
 		<module name="com.liferay.source.formatter.checkstyle.check.AssertEqualsCheck">

--- a/modules/util/source-formatter/src/main/resources/documentation/all_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/all_checks.markdown
@@ -9,6 +9,7 @@ AppendCheck | [Styling](styling_checks.markdown#styling-checks) | .java, .jsp, .
 ArquillianCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .java | Checks for correct use of `com.liferay.arquillian.extension.junit.bridge.junit.Arquillian`. |
 [ArrayCheck](check/array_check.markdown#arraycheck) | [Performance](performance_checks.markdown#performance-checks) | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Checks if performance can be improved by using different methods that can be used by collections. |
 [ArrayTypeStyleCheck](https://checkstyle.sourceforge.io/checks/misc/arraytypestyle.html) | [Styling](styling_checks.markdown#styling-checks) | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Checks the style of array type definitions. |
+ArrayUtilCheck | [Styling](styling_checks.markdown#styling-checks) | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Checks for utilization of class `ArrayUtil`. |
 [AssertEqualsCheck](check/assert_equals_check.markdown#assertequalscheck) | [Styling](styling_checks.markdown#styling-checks) | .java | Checks that additional information is provided when calling `Assert.assertEquals`. |
 AssertFailCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .java | Checks that calls to `Assert.fail` can be only used inside a try block as the last statement. |
 AssignAsUsedCheck | [Performance](performance_checks.markdown#performance-checks) | .java | Finds cases where an assign statement can be inlined or moved closer to where it is used. |

--- a/modules/util/source-formatter/src/main/resources/documentation/java_source_processor_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/java_source_processor_checks.markdown
@@ -9,6 +9,7 @@ AppendCheck | [Styling](styling_checks.markdown#styling-checks) | Checks instanc
 ArquillianCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Checks for correct use of `com.liferay.arquillian.extension.junit.bridge.junit.Arquillian`. |
 [ArrayCheck](check/array_check.markdown#arraycheck) | [Performance](performance_checks.markdown#performance-checks) | Checks if performance can be improved by using different methods that can be used by collections. |
 [ArrayTypeStyleCheck](https://checkstyle.sourceforge.io/checks/misc/arraytypestyle.html) | [Styling](styling_checks.markdown#styling-checks) | Checks the style of array type definitions. |
+ArrayUtilCheck | [Styling](styling_checks.markdown#styling-checks) | Checks for utilization of class `ArrayUtil`. |
 [AssertEqualsCheck](check/assert_equals_check.markdown#assertequalscheck) | [Styling](styling_checks.markdown#styling-checks) | Checks that additional information is provided when calling `Assert.assertEquals`. |
 AssertFailCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Checks that calls to `Assert.fail` can be only used inside a try block as the last statement. |
 AssignAsUsedCheck | [Performance](performance_checks.markdown#performance-checks) | Finds cases where an assign statement can be inlined or moved closer to where it is used. |

--- a/modules/util/source-formatter/src/main/resources/documentation/jsp_source_processor_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/jsp_source_processor_checks.markdown
@@ -5,6 +5,7 @@ Check | Category | Description
 AppendCheck | [Styling](styling_checks.markdown#styling-checks) | Checks instances where literal Strings are appended. |
 [ArrayCheck](check/array_check.markdown#arraycheck) | [Performance](performance_checks.markdown#performance-checks) | Checks if performance can be improved by using different methods that can be used by collections. |
 [ArrayTypeStyleCheck](https://checkstyle.sourceforge.io/checks/misc/arraytypestyle.html) | [Styling](styling_checks.markdown#styling-checks) | Checks the style of array type definitions. |
+ArrayUtilCheck | [Styling](styling_checks.markdown#styling-checks) | Checks for utilization of class `ArrayUtil`. |
 [AvoidNestedBlocksCheck](https://checkstyle.sourceforge.io/checks/blocks/avoidnestedblocks.html) | [Styling](styling_checks.markdown#styling-checks) | Finds nested blocks (blocks that are used freely in the code). |
 [CamelCaseNameCheck](check/camel_case_name_check.markdown#camelcasenamecheck) | [Naming Conventions](naming_conventions_checks.markdown#naming-conventions-checks) | Checks variable names for correct use of `CamelCase`. |
 ChainingCheck | [Styling](styling_checks.markdown#styling-checks) | Checks that method chaining can be used when possible. |

--- a/modules/util/source-formatter/src/main/resources/documentation/styling_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/styling_checks.markdown
@@ -5,6 +5,7 @@ Check | File Extensions | Description
 [AnnotationUseStyleCheck](https://checkstyle.sourceforge.io/checks/annotation/annotationusestyle.html) | .java | Checks the style of elements in annotations. |
 AppendCheck | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Checks instances where literal Strings are appended. |
 [ArrayTypeStyleCheck](https://checkstyle.sourceforge.io/checks/misc/arraytypestyle.html) | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Checks the style of array type definitions. |
+ArrayUtilCheck | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Checks for utilization of class `ArrayUtil`. |
 [AssertEqualsCheck](check/assert_equals_check.markdown#assertequalscheck) | .java | Checks that additional information is provided when calling `Assert.assertEquals`. |
 [AvoidNestedBlocksCheck](https://checkstyle.sourceforge.io/checks/blocks/avoidnestedblocks.html) | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Finds nested blocks (blocks that are used freely in the code). |
 BNDCapabilityCheck | .bnd | Sorts and applies logic to fix line breaks to property values for `Provide-Capability` and `Require-Capability`. |

--- a/source-formatter-suppressions.xml
+++ b/source-formatter-suppressions.xml
@@ -3,6 +3,7 @@
 <suppressions>
 	<checkstyle>
 		<suppress checks="AppendCheck" files="portal-kernel/test/unit/com/liferay/portal/kernel/util/StringBundlerTest\.java" />
+		<suppress checks="ArrayUtilCheck" files="portal-kernel/src/com/liferay/portal/kernel/util/ArrayUtil\.java" />
 		<suppress checks="CamelCaseNameCheck" files="portal-kernel/src/com/liferay/portal/kernel/cal/Duration\.java" />
 		<suppress checks="CamelCaseNameCheck" files="portal-kernel/src/com/liferay/portal/kernel/servlet/filters/invoker/InvokerFilter\.java" />
 		<suppress checks="CamelCaseNameCheck" files="portal-kernel/src/com/liferay/portal/kernel/servlet/NonSerializableObjectRequestWrapper\.java" />

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -202,6 +202,8 @@
 
     checkstyle.AppendCheck.enabled=true
 
+    checkstyle.ArrayUtilCheck.enabled=true
+
     checkstyle.ChainingCheck.requiredChainingClassFileNames=\
         portal-kernel/src/com/liferay/portal/kernel/json/JSONArray.java,\
         portal-kernel/src/com/liferay/portal/kernel/json/JSONObject.java


### PR DESCRIPTION
```
java.lang.Exception: Found 58 formatting issues:
1: Use 'ArrayUtil.isEmpty(errorMessages)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/order/importer/item/CommerceOrderImporterItemImpl.java 98 (Checkstyle:ArrayUtilCheck)
2: Use 'ArrayUtil.isEmpty(types)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/apps/commerce/commerce-discount-service/src/main/java/com/liferay/commerce/discount/internal/validator/CommerceDiscountValidatorRegistryImpl.java 87 (Checkstyle:ArrayUtilCheck)
3: Use 'ArrayUtil.isEmpty(groupIds)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/search/spi/model/query/contributor/CPDefinitionModelPreFilterContributor.java 166 (Checkstyle:ArrayUtilCheck)
4: Use 'ArrayUtil.isEmpty(cpDefinitionOptionValueRelsId)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/service/impl/CPDefinitionOptionValueRelLocalServiceImpl.java 532 (Checkstyle:ArrayUtilCheck)
5: Use 'ArrayUtil.isEmpty(groupIds)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/search/spi/model/query/contributor/CommerceOrderModelPreFilterContributor.java 85 (Checkstyle:ArrayUtilCheck)
6: Use 'ArrayUtil.isEmpty(entryKeys)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/display/context/BaseManagementToolbarDisplayContext.java 133 (Checkstyle:ArrayUtilCheck)
7: Use 'ArrayUtil.isEmpty(postalAddresses)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/AccountResourceImpl.java 675 (Checkstyle:ArrayUtilCheck)
8: Use 'ArrayUtil.isEmpty(configurations)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/manager/LayoutLockManagerImpl.java 442 (Checkstyle:ArrayUtilCheck)
9: Use 'ArrayUtil.isEmpty(values)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/collection/provider/ObjectEntrySingleFormVariationInfoCollectionProvider.java 372 (Checkstyle:ArrayUtilCheck)
10: Use 'ArrayUtil.isEmpty(configurations)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/apps/portal-configuration/portal-configuration-test-util/src/main/java/com/liferay/portal/configuration/test/util/ConfigurationTestUtil.java 113 (Checkstyle:ArrayUtilCheck)
11: Use 'ArrayUtil.isEmpty(configurations)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/apps/portal-configuration/portal-configuration-test-util/src/main/java/com/liferay/portal/configuration/test/util/ConfigurationTestUtil.java 153 (Checkstyle:ArrayUtilCheck)
12: Use 'ArrayUtil.isEmpty(serviceReferences)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/apps/portal-remote/portal-remote-jaxrs-whiteboard-debug/src/main/java/com/liferay/portal/remote/jaxrs/whiteboard/debug/osgi/commands/JaxRsServiceRuntimeOSGiCommands.java 152 (Checkstyle:ArrayUtilCheck)
13: Use 'ArrayUtil.isEmpty(_docs)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/apps/portal-search-elasticsearch7/portal-search-elasticsearch7-impl/src/main/java/com/liferay/portal/search/elasticsearch7/internal/search/response/HitsImpl.java 214 (Checkstyle:ArrayUtilCheck)
14: Use 'ArrayUtil.isEmpty(_docs)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/search/response/HitsImpl.java 214 (Checkstyle:ArrayUtilCheck)
15: Use 'ArrayUtil.isEmpty(boundaryChars)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/test/java/com/liferay/portal/search/opensearch2/internal/highlight/HighlightTranslatorTest.java 690 (Checkstyle:ArrayUtilCheck)
16: Use 'ArrayUtil.isEmpty(_docs)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/apps/portal-search-solr8/portal-search-solr8-impl/src/main/java/com/liferay/portal/search/solr8/internal/search/response/HitsImpl.java 214 (Checkstyle:ArrayUtilCheck)
17: Use 'ArrayUtil.isEmpty(groupIds)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/suggestions/spi/asah/BaseAsahSuggestionsContributor.java 96 (Checkstyle:ArrayUtilCheck)
18: Use 'ArrayUtil.isEmpty(roleIds)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/OIDCUserInfoProcessor.java 292 (Checkstyle:ArrayUtilCheck)
19: Use 'ArrayUtil.isEmpty(safeLdapFilters)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/apps/portal-security/portal-security-ldap-api/src/main/java/com/liferay/portal/security/ldap/SafeLdapFilter.java 21 (Checkstyle:ArrayUtilCheck)
20: Use 'ArrayUtil.isEmpty(safeLdapFilters)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/apps/portal-security/portal-security-ldap-api/src/main/java/com/liferay/portal/security/ldap/SafeLdapFilter.java 90 (Checkstyle:ArrayUtilCheck)
21: Use 'ArrayUtil.isEmpty(groupIds)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/InlineSQLHelperImpl.java 91 (Checkstyle:ArrayUtilCheck)
22: Use 'ArrayUtil.isEmpty(fileNames)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/apps/portal-store/portal-store-gcs/src/main/java/com/liferay/portal/store/gcs/GCSStore.java 373 (Checkstyle:ArrayUtilCheck)
23: Use 'ArrayUtil.isEmpty(values)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/apps/portal/portal-dao-orm-custom-sql-impl/src/main/java/com/liferay/portal/dao/orm/custom/sql/internal/CustomSQLImpl.java 211 (Checkstyle:ArrayUtilCheck)
24: Use 'ArrayUtil.isEmpty(keyValuesArray)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/apps/portal/portal-json-web-service-client/src/main/java/com/liferay/portal/json/web/service/client/BaseJSONWebServiceClientImpl.java 1168 (Checkstyle:ArrayUtilCheck)
25: Use 'ArrayUtil.isEmpty(liveUpgradeProcesses)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/live/LiveUpgradeExecutorImpl.java 37 (Checkstyle:ArrayUtilCheck)
26: Use 'ArrayUtil.isEmpty(fileItems)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/apps/portal/portal-upload/src/main/java/com/liferay/portal/upload/internal/ClientDataRequestHelperImpl.java 53 (Checkstyle:ArrayUtilCheck)
27: Use 'ArrayUtil.isEmpty(groupIds)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/apps/sharing/sharing-service/src/main/java/com/liferay/sharing/internal/security/permission/contributor/SharingPermissionSQLContributor.java 140 (Checkstyle:ArrayUtilCheck)
28: Use 'ArrayUtil.isEmpty(values)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/apps/static/portal-configuration/portal-configuration-metatype-api/src/main/java/com/liferay/portal/configuration/metatype/util/ParameterMapUtil.java 123 (Checkstyle:ArrayUtilCheck)
29: Use 'ArrayUtil.isEmpty(cookies)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-container-test-util/src/main/java/com/liferay/portal/osgi/web/portlet/container/test/util/PortletContainerTestUtil.java 199 (Checkstyle:ArrayUtilCheck)
30: Use 'ArrayUtil.isEmpty(files)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-generator-impl/src/main/java/com/liferay/portal/osgi/web/wab/generator/internal/processor/WabProcessor.java 216 (Checkstyle:ArrayUtilCheck)
31: Use 'ArrayUtil.isEmpty(serviceReferences)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/antivirus/antivirus-async-store-test/src/testIntegration/java/com/liferay/antivirus/async/store/internal/scheduler/test/AntivirusAsyncFileStoreSchedulerJobConfigurationTest.java 85 (Checkstyle:ArrayUtilCheck)
32: Use 'ArrayUtil.isEmpty(values)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/field/expression/handler/ExpandoUserFieldExpressionHandler.java 273 (Checkstyle:ArrayUtilCheck)
33: Use 'ArrayUtil.isEmpty(values)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/processor/BaseProcessorImpl.java 204 (Checkstyle:ArrayUtilCheck)
34: Use 'ArrayUtil.isEmpty(values)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/processor/BaseProcessorImpl.java 246 (Checkstyle:ArrayUtilCheck)
35: Use 'ArrayUtil.isEmpty(baseDirNames)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/test/poshi/poshi-core/src/main/java/com/liferay/poshi/core/PoshiContext.java 649 (Checkstyle:ArrayUtilCheck)
36: Use 'ArrayUtil.isEmpty(items)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/test/poshi/poshi-core/src/main/java/com/liferay/poshi/core/util/Dom4JUtil.java 122 (Checkstyle:ArrayUtilCheck)
37: Use 'ArrayUtil.isEmpty(strings)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/modules/test/poshi/poshi-core/src/main/java/com/liferay/poshi/core/util/StringUtil.java 107 (Checkstyle:ArrayUtilCheck)
38: Use 'ArrayUtil.isEmpty(ibmSupportedCipherSuites)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/dao/jdbc/DataSourceFactoryImpl.java 341 (Checkstyle:ArrayUtilCheck)
39: Use 'ArrayUtil.isEmpty(types)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/service/persistence/impl/RoleFinderImpl.java 428 (Checkstyle:ArrayUtilCheck)
40: Use 'ArrayUtil.isEmpty(types)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/service/persistence/impl/RoleFinderImpl.java 641 (Checkstyle:ArrayUtilCheck)
41: Use 'ArrayUtil.isEmpty(textObj)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java 586 (Checkstyle:ArrayUtilCheck)
42: Use 'ArrayUtil.isEmpty(targetClusterNodeIds)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/cluster/ClusterRequest.java 36 (Checkstyle:ArrayUtilCheck)
43: Use 'ArrayUtil.isEmpty(values)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/search/DocumentImpl.java 1044 (Checkstyle:ArrayUtilCheck)
44: Use 'ArrayUtil.isEmpty(_docs)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/search/HitsImpl.java 209 (Checkstyle:ArrayUtilCheck)
45: Use 'ArrayUtil.isEmpty(serviceClasses)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/spring/osgi/OSGiBeanProperties.java 201 (Checkstyle:ArrayUtilCheck)
46: Use 'ArrayUtil.isEmpty(array)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/util/ArrayUtil.java 1052 (Checkstyle:ArrayUtilCheck)
47: Use 'ArrayUtil.isEmpty(array)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/util/ArrayUtil.java 1060 (Checkstyle:ArrayUtilCheck)
48: Use 'ArrayUtil.isEmpty(array)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/util/ArrayUtil.java 1068 (Checkstyle:ArrayUtilCheck)
49: Use 'ArrayUtil.isEmpty(array)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/util/ArrayUtil.java 1076 (Checkstyle:ArrayUtilCheck)
50: Use 'ArrayUtil.isEmpty(array)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/util/ArrayUtil.java 1084 (Checkstyle:ArrayUtilCheck)
51: Use 'ArrayUtil.isEmpty(array)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/util/ArrayUtil.java 1092 (Checkstyle:ArrayUtilCheck)
52: Use 'ArrayUtil.isEmpty(array)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/util/ArrayUtil.java 1100 (Checkstyle:ArrayUtilCheck)
53: Use 'ArrayUtil.isEmpty(array)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/util/ArrayUtil.java 1108 (Checkstyle:ArrayUtilCheck)
54: Use 'ArrayUtil.isEmpty(array)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/portal-kernel/src/com/liferay/portal/kernel/util/ArrayUtil.java 1116 (Checkstyle:ArrayUtilCheck)
55: Use 'ArrayUtil.isEmpty(serviceReferences)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/portal-test/src/com/liferay/portal/test/rule/InjectTestBag.java 237 (Checkstyle:ArrayUtilCheck)
56: Use 'ArrayUtil.isEmpty(types)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/workspaces/liferay-jethr0-workspace/client-extensions/liferay-jethr0-etc-spring-boot/src/main/java/com/liferay/jethr0/git/dalo/GitBranchEntityDALO.java 31 (Checkstyle:ArrayUtilCheck)
57: Use 'ArrayUtil.isEmpty(types)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/workspaces/liferay-jethr0-workspace/client-extensions/liferay-jethr0-etc-spring-boot/src/main/java/com/liferay/jethr0/git/repository/GitBranchEntityRepository.java 67 (Checkstyle:ArrayUtilCheck)
58: Use 'ArrayUtil.isEmpty(opts)' to simplify code: /Users/alan/liferay_code/master/liferay-portal/workspaces/liferay-jethr0-workspace/client-extensions/liferay-jethr0-etc-spring-boot/src/main/java/com/liferay/jethr0/util/PropertiesUtil.java 134 (Checkstyle:ArrayUtilCheck)

```