### PR TITLE
LPD-37215 Check method for set SafeCloseable

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/portlet/AccountEntriesAdminPortlet.java
+++ b/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/portlet/AccountEntriesAdminPortlet.java
@@ -49,7 +49,8 @@ public class AccountEntriesAdminPortlet extends MVCPortlet {
 		throws IOException, PortletException {
 
 		try (SafeCloseable safeCloseable =
-				AllowEditAccountRoleThreadLocal.setWithSafeCloseable(true)) {
+				AllowEditAccountRoleThreadLocal.
+					setAllowEditAccountRoleWithSafeCloseable(true)) {
 
 			super.doDispatch(renderRequest, renderResponse);
 		}

--- a/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/util/AllowEditAccountRoleThreadLocal.java
+++ b/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/util/AllowEditAccountRoleThreadLocal.java
@@ -25,7 +25,7 @@ public class AllowEditAccountRoleThreadLocal {
 		return allowEditAccountRole;
 	}
 
-	public static SafeCloseable setWithSafeCloseable(
+	public static SafeCloseable setAllowEditAccountRoleWithSafeCloseable(
 		Boolean allowEditAccountRole) {
 
 		boolean currentAllowEditAccountRole = _allowEditAccountRole.get();

--- a/modules/apps/account/account-api/src/main/java/com/liferay/account/role/AccountRolePermissionThreadLocal.java
+++ b/modules/apps/account/account-api/src/main/java/com/liferay/account/role/AccountRolePermissionThreadLocal.java
@@ -22,7 +22,9 @@ public class AccountRolePermissionThreadLocal {
 		_accountEntryId.set(accountEntryId);
 	}
 
-	public static SafeCloseable setWithSafeCloseable(long accountEntryId) {
+	public static SafeCloseable setAccountEntryIdWithSafeCloseable(
+		long accountEntryId) {
+
 		return _accountEntryId.setWithSafeCloseable(accountEntryId);
 	}
 

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/search/spi/model/permission/AccountRoleSearchPermissionFilterContributor.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/search/spi/model/permission/AccountRoleSearchPermissionFilterContributor.java
@@ -108,8 +108,8 @@ public class AccountRoleSearchPermissionFilterContributor
 					});
 
 			try (SafeCloseable safeCloseable =
-					AccountRolePermissionThreadLocal.setWithSafeCloseable(
-						accountEntryId)) {
+					AccountRolePermissionThreadLocal.
+						setAccountEntryIdWithSafeCloseable(accountEntryId)) {
 
 				for (AccountRole accountRole : accountRoles) {
 					if (!accountRoleIds.contains(accountRole.getRoleId()) &&

--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountRoleServiceImpl.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/service/impl/AccountRoleServiceImpl.java
@@ -69,8 +69,8 @@ public class AccountRoleServiceImpl extends AccountRoleServiceBaseImpl {
 		throws PortalException {
 
 		try (SafeCloseable safeCloseable =
-				AccountRolePermissionThreadLocal.setWithSafeCloseable(
-					accountEntryId)) {
+				AccountRolePermissionThreadLocal.
+					setAccountEntryIdWithSafeCloseable(accountEntryId)) {
 
 			_accountRoleModelResourcePermission.check(
 				getPermissionChecker(), accountRoleId,
@@ -150,8 +150,8 @@ public class AccountRoleServiceImpl extends AccountRoleServiceBaseImpl {
 		throws PortalException {
 
 		try (SafeCloseable safeCloseable =
-				AccountRolePermissionThreadLocal.setWithSafeCloseable(
-					accountEntryId)) {
+				AccountRolePermissionThreadLocal.
+					setAccountEntryIdWithSafeCloseable(accountEntryId)) {
 
 			for (long accountRoleId : accountRoleIds) {
 				_accountRoleModelResourcePermission.check(
@@ -173,8 +173,8 @@ public class AccountRoleServiceImpl extends AccountRoleServiceBaseImpl {
 		throws PortalException {
 
 		try (SafeCloseable safeCloseable =
-				AccountRolePermissionThreadLocal.setWithSafeCloseable(
-					accountEntryId)) {
+				AccountRolePermissionThreadLocal.
+					setAccountEntryIdWithSafeCloseable(accountEntryId)) {
 
 			_accountRoleModelResourcePermission.check(
 				getPermissionChecker(), accountRoleId,

--- a/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/internal/security/permission/resource/test/AccountRoleModelResourcePermissionTest.java
+++ b/modules/apps/account/account-test/src/testIntegration/java/com/liferay/account/internal/security/permission/resource/test/AccountRoleModelResourcePermissionTest.java
@@ -67,8 +67,9 @@ public class AccountRoleModelResourcePermissionTest {
 		AccountEntry accountEntryB = AccountEntryTestUtil.addAccountEntry();
 
 		try (SafeCloseable safeCloseable =
-				AccountRolePermissionThreadLocal.setWithSafeCloseable(
-					accountEntryB.getAccountEntryId())) {
+				AccountRolePermissionThreadLocal.
+					setAccountEntryIdWithSafeCloseable(
+						accountEntryB.getAccountEntryId())) {
 
 			_testPermissions(
 				Assert::assertFalse, accountEntry, ownedAccountRole);
@@ -82,8 +83,9 @@ public class AccountRoleModelResourcePermissionTest {
 		_testPermissions(Assert::assertFalse, accountEntry, sharedAccountRole);
 
 		try (SafeCloseable safeCloseable =
-				AccountRolePermissionThreadLocal.setWithSafeCloseable(
-					accountEntry.getAccountEntryId())) {
+				AccountRolePermissionThreadLocal.
+					setAccountEntryIdWithSafeCloseable(
+						accountEntry.getAccountEntryId())) {
 
 			_testPermissions(
 				Assert::assertTrue, accountEntry, sharedAccountRole);

--- a/modules/apps/asset/asset-auto-tagger-service/src/main/java/com/liferay/asset/auto/tagger/internal/osgi/commands/AssetAutoTaggerOSGiCommands.java
+++ b/modules/apps/asset/asset-auto-tagger-service/src/main/java/com/liferay/asset/auto/tagger/internal/osgi/commands/AssetAutoTaggerOSGiCommands.java
@@ -147,7 +147,7 @@ public class AssetAutoTaggerOSGiCommands implements OSGiCommands {
 			actionableDynamicQuery.setPerformActionMethod(
 				(AssetEntry assetEntry) -> {
 					try (SafeCloseable safeCloseable =
-							CompanyThreadLocal.setWithSafeCloseable(
+							CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 								assetEntry.getCompanyId())) {
 
 						consumer.accept(assetEntry);

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineExportTaskExecutorImpl.java
@@ -62,9 +62,10 @@ public class BatchEngineExportTaskExecutorImpl
 
 	@Override
 	public void execute(BatchEngineExportTask batchEngineExportTask) {
-		SafeCloseable safeCloseable = CompanyThreadLocal.setWithSafeCloseable(
-			batchEngineExportTask.getCompanyId(),
-			CTCollectionThreadLocal.getCTCollectionId());
+		SafeCloseable safeCloseable =
+			CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+				batchEngineExportTask.getCompanyId(),
+				CTCollectionThreadLocal.getCTCollectionId());
 
 		try {
 			batchEngineExportTask.setExecuteStatus(

--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineImportTaskExecutorImpl.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/BatchEngineImportTaskExecutorImpl.java
@@ -98,9 +98,10 @@ public class BatchEngineImportTaskExecutorImpl
 			startTime = System.currentTimeMillis();
 		}
 
-		SafeCloseable safeCloseable1 = CompanyThreadLocal.setWithSafeCloseable(
-			batchEngineImportTask.getCompanyId(),
-			CTCollectionThreadLocal.getCTCollectionId());
+		SafeCloseable safeCloseable1 =
+			CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+				batchEngineImportTask.getCompanyId(),
+				CTCollectionThreadLocal.getCTCollectionId());
 
 		File file;
 

--- a/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/batch/engine/broker/test/BatchEngineBrokerTest.java
+++ b/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/batch/engine/broker/test/BatchEngineBrokerTest.java
@@ -625,7 +625,7 @@ public class BatchEngineBrokerTest {
 		_company2 = CompanyTestUtil.addCompany(true);
 
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 					_company2.getCompanyId())) {
 
 			User user = UserTestUtil.getAdminUser(_company2.getCompanyId());

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/context/CommerceContextThreadLocal.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/context/CommerceContextThreadLocal.java
@@ -21,7 +21,7 @@ public class CommerceContextThreadLocal {
 		_commerceContext.set(commerceContext);
 	}
 
-	public static SafeCloseable setWithSafeCloseable(
+	public static SafeCloseable setCommerceContextWithSafeCloseable(
 		CommerceContext commerceContext) {
 
 		return _commerceContext.setWithSafeCloseable(commerceContext);

--- a/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/context/CommerceGroupThreadLocal.java
+++ b/modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/context/CommerceGroupThreadLocal.java
@@ -23,7 +23,9 @@ public class CommerceGroupThreadLocal {
 		_commerceGroup.set(group);
 	}
 
-	public static SafeCloseable setWithSafeCloseable(long groupId) {
+	public static SafeCloseable setCommerceGroupWithSafeCloseable(
+		long groupId) {
+
 		return _commerceGroup.setWithSafeCloseable(
 			GroupLocalServiceUtil.fetchGroup(groupId));
 	}

--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceDBPartitionTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceDBPartitionTest.java
@@ -734,7 +734,7 @@ public class CompanyLocalServiceDBPartitionTest
 		String pid = null;
 
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(companyId)) {
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId)) {
 
 			pid = ConfigurationTestUtil.createFactoryConfiguration(
 				CompanyLocalServiceDBPartitionTest.class.getName(),

--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceDBPartitionTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceDBPartitionTest.java
@@ -388,7 +388,8 @@ public class CompanyLocalServiceDBPartitionTest
 				_getRulesCount(getPartitionName(copiedCompany.getCompanyId())));
 
 			SafeCloseable safeCloseable =
-				PortalInstances.setCopyInProcessCompanyId(copiedCompanyId);
+				PortalInstances.setCopyInProcessCompanyIdWithSafeCloseable(
+					copiedCompanyId);
 
 			safeCloseable.close();
 		}
@@ -423,7 +424,8 @@ public class CompanyLocalServiceDBPartitionTest
 			_checkPartitionDoesNotExist(toCompanyId);
 
 			SafeCloseable safeCloseable =
-				PortalInstances.setCopyInProcessCompanyId(toCompanyId);
+				PortalInstances.setCopyInProcessCompanyIdWithSafeCloseable(
+					toCompanyId);
 
 			safeCloseable.close();
 		}
@@ -475,7 +477,8 @@ public class CompanyLocalServiceDBPartitionTest
 			_checkPartitionDoesNotExist(toCompanyId);
 
 			SafeCloseable safeCloseable =
-				PortalInstances.setCopyInProcessCompanyId(toCompanyId);
+				PortalInstances.setCopyInProcessCompanyIdWithSafeCloseable(
+					toCompanyId);
 
 			safeCloseable.close();
 		}

--- a/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/scheduler/test/SchedulerResponseManagerTest.java
+++ b/modules/apps/dispatch/dispatch-test/src/testIntegration/java/com/liferay/dispatch/scheduler/test/SchedulerResponseManagerTest.java
@@ -100,7 +100,7 @@ public class SchedulerResponseManagerTest {
 		_company = CompanyTestUtil.addCompany();
 
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 					_company.getCompanyId())) {
 
 			_schedulerResponseManager.run(

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenAddingAFileEntryTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/app/service/test/DLAppServiceWhenAddingAFileEntryTest.java
@@ -463,7 +463,8 @@ public class DLAppServiceWhenAddingAFileEntryTest extends BaseDLAppTestCase {
 		@Override
 		protected void doRun() throws Exception {
 			try (SafeCloseable safeCloseable =
-					BufferedIncrementThreadLocal.setWithSafeCloseable(true)) {
+					BufferedIncrementThreadLocal.setForceSyncWithSafeCloseable(
+						true)) {
 
 				FileEntry fileEntry = DLAppServiceTestUtil.addFileEntry(
 					group.getGroupId(), parentFolder.getFolderId(),

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/exportimport/data/handler/test/DDMFormInstanceStagedModelDataHandlerTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/exportimport/data/handler/test/DDMFormInstanceStagedModelDataHandlerTest.java
@@ -118,7 +118,7 @@ public class DDMFormInstanceStagedModelDataHandlerTest
 		Company company = CompanyTestUtil.addCompany();
 
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 					company.getCompanyId())) {
 
 			User user = UserTestUtil.getAdminUser(company.getCompanyId());

--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/feature/flag/FeatureFlagsBagProviderImpl.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/feature/flag/FeatureFlagsBagProviderImpl.java
@@ -188,7 +188,8 @@ public class FeatureFlagsBagProviderImpl
 		}
 		else {
 			try (SafeCloseable safeCloseable =
-					CompanyThreadLocal.setWithSafeCloseable(companyId)) {
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+						companyId)) {
 
 				_populateFeatureFlagsMap(
 					companyId, featureFlags, systemFeatureFlags);

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-drop-zone/src/main/java/com/liferay/fragment/entry/processor/drop/zone/listener/DropZoneFragmentEntryLinkListener.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-drop-zone/src/main/java/com/liferay/fragment/entry/processor/drop/zone/listener/DropZoneFragmentEntryLinkListener.java
@@ -219,8 +219,8 @@ public class DropZoneFragmentEntryLinkListener
 			}
 
 			try (SafeCloseable safeCloseable =
-					CheckUnlockedLayoutThreadLocal.setWithSafeCloseable(
-						false)) {
+					CheckUnlockedLayoutThreadLocal.
+						setCheckUnlockedLayoutWithSafeCloseable(false)) {
 
 				_layoutPageTemplateStructureLocalService.
 					updateLayoutPageTemplateStructureData(
@@ -419,8 +419,8 @@ public class DropZoneFragmentEntryLinkListener
 
 		if (update) {
 			try (SafeCloseable safeCloseable =
-					CheckUnlockedLayoutThreadLocal.setWithSafeCloseable(
-						false)) {
+					CheckUnlockedLayoutThreadLocal.
+						setCheckUnlockedLayoutWithSafeCloseable(false)) {
 
 				_layoutPageTemplateStructureLocalService.
 					updateLayoutPageTemplateStructureData(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/AccountRoleResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/AccountRoleResourceImpl.java
@@ -164,8 +164,8 @@ public class AccountRoleResourceImpl extends BaseAccountRoleResourceImpl {
 		}
 
 		try (SafeCloseable safeCloseable =
-				AccountRolePermissionThreadLocal.setWithSafeCloseable(
-					accountId)) {
+				AccountRolePermissionThreadLocal.
+					setAccountEntryIdWithSafeCloseable(accountId)) {
 
 			return SearchUtil.search(
 				null,

--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/UpdateLayoutStatusThreadLocal.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/UpdateLayoutStatusThreadLocal.java
@@ -17,7 +17,7 @@ public class UpdateLayoutStatusThreadLocal {
 		return _updateLayoutStatus.get();
 	}
 
-	public static SafeCloseable setWithSafeCloseable(
+	public static SafeCloseable setUpdateLayoutStatusWithSafeCloseable(
 		Boolean updateLayoutStatus) {
 
 		boolean currentUpdateLayoutStatus = _updateLayoutStatus.get();

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/model/listener/LayoutPageTemplateEntryModelListener.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/model/listener/LayoutPageTemplateEntryModelListener.java
@@ -206,7 +206,8 @@ public class LayoutPageTemplateEntryModelListener
 		}
 
 		try (SafeCloseable safeCloseable =
-				UpdateLayoutStatusThreadLocal.setWithSafeCloseable(false)) {
+				UpdateLayoutStatusThreadLocal.
+					setUpdateLayoutStatusWithSafeCloseable(false)) {
 
 			return _formItemManager.addFragmentEntryLinks(
 				_jsonFactory.createJSONObject(), formStyledLayoutStructureItem,
@@ -351,7 +352,8 @@ public class LayoutPageTemplateEntryModelListener
 		}
 
 		try (SafeCloseable safeCloseable =
-				UpdateLayoutStatusThreadLocal.setWithSafeCloseable(false)) {
+				UpdateLayoutStatusThreadLocal.
+					setUpdateLayoutStatusWithSafeCloseable(false)) {
 
 			_fragmentEntryLinkService.updateFragmentEntryLink(
 				fragmentEntryLink.getFragmentEntryLinkId(),
@@ -386,7 +388,8 @@ public class LayoutPageTemplateEntryModelListener
 			layoutStructure, segmentsExperienceId);
 
 		try (SafeCloseable safeCloseable =
-				UpdateLayoutStatusThreadLocal.setWithSafeCloseable(false)) {
+				UpdateLayoutStatusThreadLocal.
+					setUpdateLayoutStatusWithSafeCloseable(false)) {
 
 			_layoutPageTemplateStructureLocalService.
 				updateLayoutPageTemplateStructureData(

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
@@ -1536,7 +1536,8 @@ public class LayoutsImporterImpl implements LayoutsImporter {
 				layoutPageTemplateEntryType);
 
 		try (SafeCloseable safeCloseable =
-				CheckUnlockedLayoutThreadLocal.setWithSafeCloseable(false)) {
+				CheckUnlockedLayoutThreadLocal.
+					setCheckUnlockedLayoutWithSafeCloseable(false)) {
 
 			if ((layoutPageTemplateEntry != null) &&
 				Objects.equals(

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/ImportMVCActionCommand.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/ImportMVCActionCommand.java
@@ -90,8 +90,8 @@ public class ImportMVCActionCommand extends BaseMVCActionCommand {
 				Collections.emptyList();
 
 			try (SafeCloseable safeCloseable =
-					CheckUnlockedLayoutThreadLocal.setWithSafeCloseable(
-						false)) {
+					CheckUnlockedLayoutThreadLocal.
+						setCheckUnlockedLayoutWithSafeCloseable(false)) {
 
 				layoutsImporterResultEntries = _layoutsImporter.importFile(
 					themeDisplay.getUserId(), themeDisplay.getScopeGroupId(),

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/util/CheckUnlockedLayoutThreadLocal.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/util/CheckUnlockedLayoutThreadLocal.java
@@ -17,7 +17,7 @@ public class CheckUnlockedLayoutThreadLocal {
 		return _checkUnlockedLayout.get();
 	}
 
-	public static SafeCloseable setWithSafeCloseable(
+	public static SafeCloseable setCheckUnlockedLayoutWithSafeCloseable(
 		Boolean checkUnlockedLayout) {
 
 		boolean currentCheckUnlockedLayout = _checkUnlockedLayout.get();

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionThreadLocal.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionThreadLocal.java
@@ -27,7 +27,9 @@ public class ObjectDefinitionThreadLocal {
 		return false;
 	}
 
-	public static SafeCloseable setDeleteObjectDefinitionId(long id) {
+	public static SafeCloseable setDeleteObjectDefinitionIdWithSafeCloseable(
+		long id) {
+
 		return _deleteObjectDefinitionIdThreadLocal.setWithSafeCloseable(id);
 	}
 

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/search/StrictObjectReindexThreadLocal.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/search/StrictObjectReindexThreadLocal.java
@@ -17,7 +17,7 @@ public class StrictObjectReindexThreadLocal {
 		return _strictObjectReindexThreadLocal.get();
 	}
 
-	public static SafeCloseable setStrictObjectReindex(
+	public static SafeCloseable setStrictObjectReindexWithSafeCloseable(
 		boolean strictObjectReindex) {
 
 		return _strictObjectReindexThreadLocal.setWithSafeCloseable(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -565,8 +565,9 @@ public class ObjectDefinitionLocalServiceImpl
 			actionableDynamicQuery.setPrimaryKeyPropertyName("objectEntryId");
 
 			try (SafeCloseable safeCloseable =
-					ObjectDefinitionThreadLocal.setDeleteObjectDefinitionId(
-						objectDefinition.getObjectDefinitionId())) {
+					ObjectDefinitionThreadLocal.
+						setDeleteObjectDefinitionIdWithSafeCloseable(
+							objectDefinition.getObjectDefinitionId())) {
 
 				actionableDynamicQuery.performActions();
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -692,7 +692,7 @@ public class ObjectDefinitionLocalServiceImpl
 				entry.getValue();
 
 			try (SafeCloseable safeCloseable =
-					CompanyThreadLocal.setWithSafeCloseable(
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 						objectDefinition.getCompanyId())) {
 
 				serviceRegistrationsMap.computeIfAbsent(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -4048,7 +4048,8 @@ public class ObjectEntryLocalServiceImpl
 			objectDefinition.getClassName());
 
 		try (SafeCloseable safeCloseable =
-				StrictObjectReindexThreadLocal.setStrictObjectReindex(true)) {
+				StrictObjectReindexThreadLocal.
+					setStrictObjectReindexWithSafeCloseable(true)) {
 
 			indexer.reindex(objectEntry);
 		}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/ObjectRelatedModelsProviderTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/related/models/test/ObjectRelatedModelsProviderTest.java
@@ -752,7 +752,7 @@ public class ObjectRelatedModelsProviderTest {
 		String originalName = PrincipalThreadLocal.getName();
 
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(companyId)) {
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId)) {
 
 			_setUser(user);
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceDBPartitionTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceDBPartitionTest.java
@@ -70,7 +70,7 @@ public class ObjectDefinitionLocalServiceDBPartitionTest
 		int resourceActionsCount) {
 
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(companyId)) {
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId)) {
 
 			Assert.assertEquals(
 				resourceActionsCount,

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectDefinitionLocalServiceTest.java
@@ -1422,7 +1422,7 @@ public class ObjectDefinitionLocalServiceTest {
 		PortalInstances.initCompany(company);
 
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 					company.getCompanyId())) {
 
 			User user = UserTestUtil.getAdminUser(company.getCompanyId());

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectFolderLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectFolderLocalServiceTest.java
@@ -153,7 +153,7 @@ public class ObjectFolderLocalServiceTest {
 		ObjectFolder objectFolder = null;
 
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 					company.getCompanyId())) {
 
 			User user = UserTestUtil.getAdminUser(company.getCompanyId());

--- a/modules/apps/on-demand-admin/on-demand-admin-impl/src/main/java/com/liferay/on/demand/admin/internal/ticket/generator/OnDemandAdminTicketGeneratorImpl.java
+++ b/modules/apps/on-demand-admin/on-demand-admin-impl/src/main/java/com/liferay/on/demand/admin/internal/ticket/generator/OnDemandAdminTicketGeneratorImpl.java
@@ -94,7 +94,7 @@ public class OnDemandAdminTicketGeneratorImpl
 			onDemandAdminConfiguration.authenticationTokenExpirationTime();
 
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 					company.getCompanyId())) {
 
 			return _ticketLocalService.addDistinctTicket(
@@ -113,7 +113,7 @@ public class OnDemandAdminTicketGeneratorImpl
 		throws PortalException {
 
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(companyId)) {
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId)) {
 
 			String password = PwdGenerator.getPassword(20);
 

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/BackgroundTaskInExecutionUtil.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/BackgroundTaskInExecutionUtil.java
@@ -20,7 +20,9 @@ public class BackgroundTaskInExecutionUtil {
 		return _backgroundTaskIds.contains(backgroundTaskId);
 	}
 
-	public static SafeCloseable setInExecution(long backgroundTaskId) {
+	public static SafeCloseable setInExecutionWithSafeCloseable(
+		long backgroundTaskId) {
+
 		_backgroundTaskIds.add(backgroundTaskId);
 
 		return () -> _backgroundTaskIds.remove(backgroundTaskId);

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/messaging/BackgroundTaskMessageListener.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/messaging/BackgroundTaskMessageListener.java
@@ -71,7 +71,7 @@ public class BackgroundTaskMessageListener extends BaseMessageListener {
 				BackgroundTaskThreadLocal.setBackgroundTaskIdWithSafeCloseable(
 					backgroundTaskId);
 			SafeCloseable safeCloseable2 =
-				BackgroundTaskInExecutionUtil.setInExecution(
+				BackgroundTaskInExecutionUtil.setInExecutionWithSafeCloseable(
 					backgroundTaskId)) {
 
 			ServiceContext serviceContext = new ServiceContext();

--- a/modules/apps/portal-cache/portal-cache-impl/src/main/java/com/liferay/portal/cache/internal/dao/orm/EntityCacheImpl.java
+++ b/modules/apps/portal-cache/portal-cache-impl/src/main/java/com/liferay/portal/cache/internal/dao/orm/EntityCacheImpl.java
@@ -331,7 +331,7 @@ public class EntityCacheImpl
 		boolean updateByEntityCache) {
 
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(companyId)) {
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId)) {
 
 			_notify(className, baseModel, updateByEntityCache);
 		}

--- a/modules/apps/portal-cache/portal-cache-multiple/src/main/java/com/liferay/portal/cache/multiple/internal/cluster/link/messaging/ClusterLinkPortalCacheClusterListener.java
+++ b/modules/apps/portal-cache/portal-cache-multiple/src/main/java/com/liferay/portal/cache/multiple/internal/cluster/link/messaging/ClusterLinkPortalCacheClusterListener.java
@@ -78,7 +78,7 @@ public class ClusterLinkPortalCacheClusterListener extends BaseMessageListener {
 
 		if (portalCache.isSharded()) {
 			try (SafeCloseable safeCloseable =
-					CompanyThreadLocal.setWithSafeCloseable(
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 						ClusterLinkMessageUtil.getCompanyId(message))) {
 
 				_handlePortalCacheClusterEvent(message, portalCache);

--- a/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/internal/provider/PLOOriginalTranslationProviderImpl.java
+++ b/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/internal/provider/PLOOriginalTranslationProviderImpl.java
@@ -24,7 +24,8 @@ public class PLOOriginalTranslationProviderImpl
 	@Override
 	public String get(Locale locale, String key) {
 		try (SafeCloseable safeCloseable =
-				PLOOriginalTranslationThreadLocal.setWithSafeCloseable(true)) {
+				PLOOriginalTranslationThreadLocal.
+					setUseOriginalTranslationWithSafeCloseable(true)) {
 
 			return _language.get(locale, key, null);
 		}

--- a/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/internal/provider/PLOOriginalTranslationThreadLocal.java
+++ b/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/internal/provider/PLOOriginalTranslationThreadLocal.java
@@ -25,7 +25,7 @@ public class PLOOriginalTranslationThreadLocal {
 		return useOriginalTranslation;
 	}
 
-	public static SafeCloseable setWithSafeCloseable(
+	public static SafeCloseable setUseOriginalTranslationWithSafeCloseable(
 		Boolean useOriginalTranslation) {
 
 		return _useOriginalTranslation.setWithSafeCloseable(

--- a/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/service/impl/PLOEntryLocalServiceImpl.java
+++ b/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/service/impl/PLOEntryLocalServiceImpl.java
@@ -129,7 +129,7 @@ public class PLOEntryLocalServiceImpl extends PLOEntryLocalServiceBaseImpl {
 		}
 
 		try (SafeCloseable safeCloseable =
-				ClusterInvokeThreadLocal.setWithSafeCloseable(false)) {
+				ClusterInvokeThreadLocal.setEnabledWithSafeCloseable(false)) {
 
 			for (Map.Entry<Object, Object> entry : properties.entrySet()) {
 				_addOrUpdatePLOEntry(

--- a/modules/apps/portal-scheduler/portal-scheduler-quartz-test/src/testIntegration/java/com/liferay/portal/scheduler/quartz/internal/upgrade/v1_0_1/test/QuartzUpgradeProcessTest.java
+++ b/modules/apps/portal-scheduler/portal-scheduler-quartz-test/src/testIntegration/java/com/liferay/portal/scheduler/quartz/internal/upgrade/v1_0_1/test/QuartzUpgradeProcessTest.java
@@ -195,7 +195,7 @@ public class QuartzUpgradeProcessTest {
 		long companyId2 = _company.getCompanyId();
 
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(companyId2)) {
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId2)) {
 
 			_ctCollection = _ctCollectionLocalService.addCTCollection(
 				null, companyId2, TestPropsValues.getUserId(), 0, "test", null);

--- a/modules/apps/portal-security-audit/portal-security-audit-wiring/src/main/java/com/liferay/portal/security/audit/wiring/internal/servlet/filter/AuditFilter.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-wiring/src/main/java/com/liferay/portal/security/audit/wiring/internal/servlet/filter/AuditFilter.java
@@ -94,7 +94,7 @@ public class AuditFilter extends BaseFilter implements TryFilter {
 
 		if (userId != null) {
 			try (SafeCloseable safeCloseable =
-					CompanyThreadLocal.setWithSafeCloseable(
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 						_portal.getCompanyId(httpServletRequest))) {
 
 				User user = _userLocalService.fetchUser(userId);

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/configuration/instance/lifecycle/OpenIdConnectProviderPortalInstanceLifecycleListener.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/configuration/instance/lifecycle/OpenIdConnectProviderPortalInstanceLifecycleListener.java
@@ -504,7 +504,8 @@ public class OpenIdConnectProviderPortalInstanceLifecycleListener
 			}
 			else {
 				try (SafeCloseable safeCloseable =
-						CompanyThreadLocal.setWithSafeCloseable(companyId)) {
+						CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+							companyId)) {
 
 					_deleteOAuthClientEntry(companyId, properties);
 				}
@@ -539,7 +540,8 @@ public class OpenIdConnectProviderPortalInstanceLifecycleListener
 			}
 
 			try (SafeCloseable safeCloseable =
-					CompanyThreadLocal.setWithSafeCloseable(companyId)) {
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+						companyId)) {
 
 				_updateOAuthClientEntry(companyId, oldProperties, properties);
 			}

--- a/modules/apps/portal-template/portal-template-freemarker/src/test/java/com/liferay/portal/template/freemarker/internal/RestrictedLiferayObjectWrapperTest.java
+++ b/modules/apps/portal-template/portal-template-freemarker/src/test/java/com/liferay/portal/template/freemarker/internal/RestrictedLiferayObjectWrapperTest.java
@@ -437,8 +437,9 @@ public class RestrictedLiferayObjectWrapperTest
 				// Base model with wrong company ID and disabled checking
 
 				try (SafeCloseable safeCloseable =
-						CompanyThreadLocal.setInitializingPortalInstance(
-							true)) {
+						CompanyThreadLocal.
+							setInitializingPortalInstanceWithSafeCloseable(
+								true)) {
 
 					objectWrapper.wrap(new TestBaseModel(123L));
 				}

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/petra/executor/GraphWalkerPortalExecutor.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-runtime-impl/src/main/java/com/liferay/portal/workflow/kaleo/runtime/internal/petra/executor/GraphWalkerPortalExecutor.java
@@ -71,8 +71,9 @@ public class GraphWalkerPortalExecutor {
 				_noticeableExecutorService.submit(
 					() -> {
 						try (SafeCloseable safeCloseable =
-								CompanyThreadLocal.setWithSafeCloseable(
-									companyId, ctCollectionId)) {
+								CompanyThreadLocal.
+									setCompanyIdWithSafeCloseable(
+										companyId, ctCollectionId)) {
 
 							_walk(pathElement);
 						}
@@ -92,7 +93,7 @@ public class GraphWalkerPortalExecutor {
 			_noticeableExecutorService.submit(
 				() -> {
 					try (SafeCloseable safeCloseable =
-							CompanyThreadLocal.setWithSafeCloseable(
+							CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 								companyId, ctCollectionId)) {
 
 						_walk(pathElement);

--- a/modules/apps/portal/portal-db-partition-test-util/src/main/java/com/liferay/portal/db/partition/test/util/BaseDBPartitionTestCase.java
+++ b/modules/apps/portal/portal-db-partition-test-util/src/main/java/com/liferay/portal/db/partition/test/util/BaseDBPartitionTestCase.java
@@ -139,7 +139,8 @@ public abstract class BaseDBPartitionTestCase {
 		try (Statement statement = connection.createStatement()) {
 			for (long companyId : COMPANY_IDS) {
 				try (SafeCloseable safeCloseable =
-						CompanyThreadLocal.setWithSafeCloseable(companyId)) {
+						CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+							companyId)) {
 
 					statement.execute(
 						"delete from Company where companyId = " + companyId);
@@ -241,7 +242,7 @@ public abstract class BaseDBPartitionTestCase {
 	protected static void insertPartitionData() throws Exception {
 		for (long companyId : COMPANY_IDS) {
 			try (SafeCloseable safeCloseable =
-					CompanyThreadLocal.setWithSafeCloseable(companyId);
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId);
 				PreparedStatement preparedStatement1 =
 					connection.prepareStatement(
 						"insert into Group_ (mvccVersion, ctCollectionId, " +
@@ -307,7 +308,7 @@ public abstract class BaseDBPartitionTestCase {
 	protected static void insertPartitionRequiredData() throws Exception {
 		for (long companyId : COMPANY_IDS) {
 			try (SafeCloseable safeCloseable =
-					CompanyThreadLocal.setWithSafeCloseable(companyId);
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId);
 				PreparedStatement preparedStatement1 =
 					connection.prepareStatement(
 						"insert into Company (companyId, mx, webId) values " +

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
@@ -106,7 +106,7 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 	@Test
 	public void testAddIndexControlTableSystemCompany() throws Exception {
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 					CompanyConstants.SYSTEM)) {
 
 			createIndex(TEST_CONTROL_TABLE_NAME);
@@ -313,7 +313,8 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 	@Test
 	public void testCounterGetNames() throws Exception {
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(COMPANY_IDS[0])) {
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					COMPANY_IDS[0])) {
 
 			_counterLocalService.increment(_CLASS_NAME);
 
@@ -348,7 +349,8 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 	@Test
 	public void testCounterIncrementWithName() throws Exception {
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(COMPANY_IDS[0])) {
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					COMPANY_IDS[0])) {
 
 			Assert.assertEquals(
 				1, _counterLocalService.increment(getClass().getName()));
@@ -370,7 +372,8 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 	@Test
 	public void testCounterIncrementWithNameAndSize() throws Exception {
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(COMPANY_IDS[0])) {
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					COMPANY_IDS[0])) {
 
 			Assert.assertEquals(
 				10, _counterLocalService.increment(_CLASS_NAME, 10));
@@ -394,7 +397,8 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 	@Test
 	public void testCounterRename() throws Exception {
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(COMPANY_IDS[0])) {
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					COMPANY_IDS[0])) {
 
 			try {
 				DBPartitionUtil.forEachCompanyId(
@@ -432,7 +436,8 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 	@Test
 	public void testCounterReset() throws Exception {
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(COMPANY_IDS[0])) {
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					COMPANY_IDS[0])) {
 
 			DBPartitionUtil.forEachCompanyId(
 				companyId -> _counterLocalService.increment(_CLASS_NAME));
@@ -456,7 +461,8 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 	@Test
 	public void testCounterResetWithIncrement() throws Exception {
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(COMPANY_IDS[0])) {
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					COMPANY_IDS[0])) {
 
 			DBPartitionUtil.forEachCompanyId(
 				companyId -> _counterLocalService.increment(_CLASS_NAME));

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionUtilTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionUtilTest.java
@@ -160,7 +160,8 @@ public class DBPartitionUtilTest extends BaseDBPartitionTestCase {
 				"TestObjectTable_x_");
 
 			try (SafeCloseable safeCloseable =
-					CompanyThreadLocal.setWithSafeCloseable(COMPANY_IDS[0])) {
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+						COMPANY_IDS[0])) {
 
 				createAndPopulateTable(
 					testObjectTableNamePrefix + COMPANY_IDS[0]);
@@ -460,7 +461,7 @@ public class DBPartitionUtilTest extends BaseDBPartitionTestCase {
 		throws Exception {
 
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(companyId);
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId);
 			PreparedStatement preparedStatement = connection.prepareStatement(
 				"select primKey, primKeyId from ResourcePermission");
 			ResultSet resultSet = preparedStatement.executeQuery()) {

--- a/modules/apps/portal/portal-db-schema-definition-test/src/testIntegration/java/com/liferay/portal/db/schema/definition/internal/exporter/test/DBPartitionDBSchemaDefinitionExporterTest.java
+++ b/modules/apps/portal/portal-db-schema-definition-test/src/testIntegration/java/com/liferay/portal/db/schema/definition/internal/exporter/test/DBPartitionDBSchemaDefinitionExporterTest.java
@@ -73,7 +73,7 @@ public class DBPartitionDBSchemaDefinitionExporterTest
 		_company = CompanyTestUtil.addCompany();
 
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 					_company.getCompanyId())) {
 
 			User adminUser = UserTestUtil.getAdminUser(_company.getCompanyId());

--- a/modules/apps/portal/portal-instance-lifecycle-api/src/main/java/com/liferay/portal/instance/lifecycle/InitialRequestPortalInstanceLifecycleListener.java
+++ b/modules/apps/portal/portal-instance-lifecycle-api/src/main/java/com/liferay/portal/instance/lifecycle/InitialRequestPortalInstanceLifecycleListener.java
@@ -90,7 +90,8 @@ public abstract class InitialRequestPortalInstanceLifecycleListener
 		InitialRequestSyncUtil.registerSyncCallable(
 			() -> {
 				try (SafeCloseable safeCloseable =
-						CompanyThreadLocal.setWithSafeCloseable(companyId)) {
+						CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+							companyId)) {
 
 					doPortalInstanceRegistered(companyId);
 				}

--- a/modules/apps/portal/portal-instance-lifecycle-impl/src/main/java/com/liferay/portal/instance/lifecycle/internal/PortalInstanceLifecycleListenerManagerImpl.java
+++ b/modules/apps/portal/portal-instance-lifecycle-impl/src/main/java/com/liferay/portal/instance/lifecycle/internal/PortalInstanceLifecycleListenerManagerImpl.java
@@ -180,8 +180,9 @@ public class PortalInstanceLifecycleListenerManagerImpl
 					LocaleThreadLocal.getSiteDefaultLocale();
 
 				try (SafeCloseable safeCloseable =
-						CompanyThreadLocal.setInitializingPortalInstance(
-							true)) {
+						CompanyThreadLocal.
+							setInitializingPortalInstanceWithSafeCloseable(
+								true)) {
 
 					CompanyThreadLocal.setCompanyId(company.getCompanyId());
 					LocaleThreadLocal.setDefaultLocale(company.getLocale());

--- a/modules/apps/portal/portal-list-type-test/src/testIntegration/java/com/liferay/portal/list/type/test/ListTypeLocalServiceTest.java
+++ b/modules/apps/portal/portal-list-type-test/src/testIntegration/java/com/liferay/portal/list/type/test/ListTypeLocalServiceTest.java
@@ -71,7 +71,7 @@ public class ListTypeLocalServiceTest {
 				false));
 
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 					_company.getCompanyId())) {
 
 			for (int i = 0; i < listTypesJSONArray.length(); i++) {
@@ -95,7 +95,7 @@ public class ListTypeLocalServiceTest {
 		ListType listType = null;
 
 		try (SafeCloseable safeCloseable1 =
-				CompanyThreadLocal.setWithSafeCloseable(
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 					_company.getCompanyId())) {
 
 			listType = _listTypeLocalService.addListType(
@@ -106,7 +106,7 @@ public class ListTypeLocalServiceTest {
 					_company.getCompanyId(), _LIST_TYPE_NAME, _LIST_TYPE_TYPE));
 
 			try (SafeCloseable safeCloseable2 =
-					CompanyThreadLocal.setWithSafeCloseable(
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 						PortalUtil.getDefaultCompanyId())) {
 
 				Assert.assertNull(
@@ -118,7 +118,7 @@ public class ListTypeLocalServiceTest {
 		finally {
 			if (listType != null) {
 				try (SafeCloseable safeCloseable =
-						CompanyThreadLocal.setWithSafeCloseable(
+						CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 							_company.getCompanyId())) {
 
 					_listTypeLocalService.deleteListType(listType);
@@ -132,7 +132,7 @@ public class ListTypeLocalServiceTest {
 		ListType listType = null;
 
 		try (SafeCloseable safeCloseable1 =
-				CompanyThreadLocal.setWithSafeCloseable(
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 					_company.getCompanyId())) {
 
 			listType = _listTypeLocalService.addListType(
@@ -144,7 +144,7 @@ public class ListTypeLocalServiceTest {
 			Assert.assertEquals(listTypes.toString(), 1, listTypes.size());
 
 			try (SafeCloseable safeCloseable2 =
-					CompanyThreadLocal.setWithSafeCloseable(
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 						PortalUtil.getDefaultCompanyId())) {
 
 				listTypes = _listTypeLocalService.getListTypes(
@@ -156,7 +156,7 @@ public class ListTypeLocalServiceTest {
 		finally {
 			if (listType != null) {
 				try (SafeCloseable safeCloseable =
-						CompanyThreadLocal.setWithSafeCloseable(
+						CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 							_company.getCompanyId())) {
 
 					_listTypeLocalService.deleteListType(listType);

--- a/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/SynchronousDestination.java
+++ b/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/SynchronousDestination.java
@@ -43,7 +43,7 @@ public class SynchronousDestination extends BaseDestination {
 		}
 
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(companyId)) {
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId)) {
 
 			_send(message);
 		}

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BasePortletPreferencesUpgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BasePortletPreferencesUpgradeProcessTest.java
@@ -60,7 +60,7 @@ public class BasePortletPreferencesUpgradeProcessTest
 	@Test
 	public void testUpgradeGroupPortletPreferences() throws Exception {
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 					CompanyConstants.SYSTEM)) {
 
 			PortletPreferences portletPreferences =
@@ -103,7 +103,7 @@ public class BasePortletPreferencesUpgradeProcessTest
 	@Test
 	public void testUpgradeLayoutPortletPreferences() throws Exception {
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 					CompanyConstants.SYSTEM)) {
 
 			PortletPreferences portletPreferences =

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeCallableTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeCallableTest.java
@@ -42,7 +42,7 @@ public class BaseUpgradeCallableTest {
 			@Override
 			protected void doUpgrade() throws Exception {
 				try (SafeCloseable safeCloseable =
-						CompanyThreadLocal.setWithSafeCloseable(
+						CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 							PortalUtil.getDefaultCompanyId())) {
 
 					ExecutorService executorService =

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/UpgradePortletPreferencesCompanyIdTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/UpgradePortletPreferencesCompanyIdTest.java
@@ -59,7 +59,7 @@ public class UpgradePortletPreferencesCompanyIdTest {
 	@Test
 	public void testUpgrade() throws Exception {
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 					CompanyConstants.SYSTEM)) {
 
 			PortletPreferences portletPreferences =

--- a/modules/apps/portlet-preferences/portlet-preferences-test/src/testIntegration/java/com/liferay/portlet/preferences/test/PortletPreferencesLocalServiceTest.java
+++ b/modules/apps/portlet-preferences/portlet-preferences-test/src/testIntegration/java/com/liferay/portlet/preferences/test/PortletPreferencesLocalServiceTest.java
@@ -98,7 +98,7 @@ public class PortletPreferencesLocalServiceTest
 		throws Exception {
 
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 					TestPropsValues.getCompanyId())) {
 
 			PortletPreferences portletPreferences =
@@ -118,7 +118,7 @@ public class PortletPreferencesLocalServiceTest
 		throws Exception {
 
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 					CompanyConstants.SYSTEM)) {
 
 			PortletPreferences portletPreferences =

--- a/modules/apps/repository/repository-test/src/testIntegration/java/com/liferay/repository/test/RepositoryFactoryDBPartitionTest.java
+++ b/modules/apps/repository/repository-test/src/testIntegration/java/com/liferay/repository/test/RepositoryFactoryDBPartitionTest.java
@@ -70,7 +70,8 @@ public class RepositoryFactoryDBPartitionTest extends BaseDBPartitionTestCase {
 		long repositoryId = count + 1000;
 
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(COMPANY_IDS[0])) {
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					COMPANY_IDS[0])) {
 
 			long groupId = count + 100;
 
@@ -81,7 +82,8 @@ public class RepositoryFactoryDBPartitionTest extends BaseDBPartitionTestCase {
 		}
 
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(COMPANY_IDS[1])) {
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					COMPANY_IDS[1])) {
 
 			long groupId = count + 200;
 
@@ -144,13 +146,15 @@ public class RepositoryFactoryDBPartitionTest extends BaseDBPartitionTestCase {
 		long count2 = 1;
 
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(COMPANY_IDS[0])) {
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					COMPANY_IDS[0])) {
 
 			count1 = _counterLocalService.increment();
 		}
 
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(COMPANY_IDS[1])) {
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					COMPANY_IDS[1])) {
 
 			count2 = _counterLocalService.increment();
 		}

--- a/modules/apps/roles/roles-admin-test/src/testIntegration/java/com/liferay/roles/admin/internal/exportimport/data/handler/test/RoleStagedModelDataHandlerTest.java
+++ b/modules/apps/roles/roles-admin-test/src/testIntegration/java/com/liferay/roles/admin/internal/exportimport/data/handler/test/RoleStagedModelDataHandlerTest.java
@@ -86,7 +86,7 @@ public class RoleStagedModelDataHandlerTest
 		Company company = CompanyTestUtil.addCompany();
 
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 					company.getCompanyId())) {
 
 			User user = UserTestUtil.getAdminUser(company.getCompanyId());

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerClientExtension.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/SiteInitializerClientExtension.java
@@ -206,7 +206,7 @@ public class SiteInitializerClientExtension
 		long companyId = company.getCompanyId();
 
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(companyId)) {
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId)) {
 
 			TransactionInvokerUtil.invoke(
 				_transactionConfig,

--- a/modules/apps/site/site-welcome-site-initializer/src/main/java/com/liferay/site/welcome/site/initializer/internal/instance/lifecycle/AddDefaultLayoutInitialRequestPortalInstanceLifecycleListener.java
+++ b/modules/apps/site/site-welcome-site-initializer/src/main/java/com/liferay/site/welcome/site/initializer/internal/instance/lifecycle/AddDefaultLayoutInitialRequestPortalInstanceLifecycleListener.java
@@ -125,7 +125,8 @@ public class AddDefaultLayoutInitialRequestPortalInstanceLifecycleListener
 		}
 
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setInitializingPortalInstance(true)) {
+				CompanyThreadLocal.
+					setInitializingPortalInstanceWithSafeCloseable(true)) {
 
 			User user = _getUser(companyId);
 

--- a/modules/apps/static/osgi/osgi-util/src/main/java/com/liferay/osgi/util/configuration/ConfigurationFactoryUtil.java
+++ b/modules/apps/static/osgi/osgi-util/src/main/java/com/liferay/osgi/util/configuration/ConfigurationFactoryUtil.java
@@ -37,7 +37,7 @@ public class ConfigurationFactoryUtil {
 		long companyId = getCompanyId(companyLocalService, properties);
 
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(companyId)) {
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId)) {
 
 			unsafeConsumer.accept(companyId);
 		}

--- a/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/configuration/ConfigurationFileInstaller.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-impl/src/main/java/com/liferay/portal/file/install/internal/configuration/ConfigurationFileInstaller.java
@@ -95,7 +95,7 @@ public class ConfigurationFileInstaller implements FileInstaller {
 		String[] pid = _parsePid(file.getName());
 
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 					_getCompanyId(
 						_getScope(dictionary), dictionary, file.getName()))) {
 
@@ -223,7 +223,7 @@ public class ConfigurationFileInstaller implements FileInstaller {
 			file.getName(), pid[0], pid[1]);
 
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 					_getCompanyId(
 						ExtendedObjectClassDefinition.Scope.COMPANY,
 						configuration.getProperties(), file.getName()))) {

--- a/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGArtifactInstaller.java
+++ b/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGArtifactInstaller.java
@@ -81,7 +81,8 @@ public class LPKGArtifactInstaller implements FileInstaller {
 		}
 
 		try (SafeCloseable safeCloseable =
-				LPKGBatchInstallThreadLocal.setBatchInstallInProcess(true)) {
+				LPKGBatchInstallThreadLocal.
+					setBatchInstallInProcessWithSafeCloseable(true)) {
 
 			_batchInstall(lpkgFiles);
 		}

--- a/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGBatchInstallThreadLocal.java
+++ b/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGBatchInstallThreadLocal.java
@@ -17,7 +17,7 @@ public class LPKGBatchInstallThreadLocal {
 		return _batchInstallInProcess.get();
 	}
 
-	public static SafeCloseable setBatchInstallInProcess(
+	public static SafeCloseable setBatchInstallInProcessWithSafeCloseable(
 		boolean batchInstallInProcess) {
 
 		return _batchInstallInProcess.setWithSafeCloseable(

--- a/modules/apps/view-count/view-count-test/src/testIntegration/java/com/liferay/view/count/service/impl/test/ViewCountEntryLocalServiceTest.java
+++ b/modules/apps/view-count/view-count-test/src/testIntegration/java/com/liferay/view/count/service/impl/test/ViewCountEntryLocalServiceTest.java
@@ -98,8 +98,8 @@ public class ViewCountEntryLocalServiceTest {
 			FutureTask<Void> futureTask = new FutureTask<>(
 				() -> {
 					try (SafeCloseable safeCloseable =
-							BufferedIncrementThreadLocal.setWithSafeCloseable(
-								true)) {
+							BufferedIncrementThreadLocal.
+								setForceSyncWithSafeCloseable(true)) {
 
 						_viewCountEntryLocalService.incrementViewCount(
 							TestPropsValues.getCompanyId(),

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/background/task/WorkflowMetricsReindexBackgroundTaskExecutor.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-service/src/main/java/com/liferay/portal/workflow/metrics/internal/background/task/WorkflowMetricsReindexBackgroundTaskExecutor.java
@@ -102,8 +102,9 @@ public class WorkflowMetricsReindexBackgroundTaskExecutor
 								getWorkflowMetricsReindexer(indexEntityName);
 
 						try (SafeCloseable safeCloseable =
-								CompanyThreadLocal.setWithSafeCloseable(
-									backgroundTask.getCompanyId())) {
+								CompanyThreadLocal.
+									setCompanyIdWithSafeCloseable(
+										backgroundTask.getCompanyId())) {
 
 							workflowMetricsReindexer.reindex(
 								backgroundTask.getCompanyId());

--- a/modules/test/company-sample-data-generation-test/src/testIntegration/java/com/liferay/company/sample/data/generation/test/CompanySampleDataGenerationTest.java
+++ b/modules/test/company-sample-data-generation-test/src/testIntegration/java/com/liferay/company/sample/data/generation/test/CompanySampleDataGenerationTest.java
@@ -154,7 +154,7 @@ public class CompanySampleDataGenerationTest {
 			// Add user
 
 			try (SafeCloseable safeCloseable =
-					CompanyThreadLocal.setWithSafeCloseable(
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 						company.getCompanyId())) {
 
 				int originalCompanyUsersCount =

--- a/modules/test/company-sample-data-generation-test/src/testIntegration/java/com/liferay/company/sample/data/generation/test/CompanySampleDataGenerationTest.java
+++ b/modules/test/company-sample-data-generation-test/src/testIntegration/java/com/liferay/company/sample/data/generation/test/CompanySampleDataGenerationTest.java
@@ -114,8 +114,8 @@ public class CompanySampleDataGenerationTest {
 				futures.add(
 					_executorService.submit(
 						() -> {
-							BufferedIncrementThreadLocal.setWithSafeCloseable(
-								true);
+							BufferedIncrementThreadLocal.
+								setForceSyncWithSafeCloseable(true);
 
 							_addCompany(companyIndex);
 

--- a/modules/util/portal-tools-db-partition-migration-validator-test/src/testIntegration/java/com/liferay/portal/tools/db/partition/migration/validator/test/DBPartitionMigrationValidatorTest.java
+++ b/modules/util/portal-tools-db-partition-migration-validator-test/src/testIntegration/java/com/liferay/portal/tools/db/partition/migration/validator/test/DBPartitionMigrationValidatorTest.java
@@ -156,7 +156,7 @@ public class DBPartitionMigrationValidatorTest extends BaseDBPartitionTestCase {
 
 	private String _testExport(long companyId) throws Exception {
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(companyId)) {
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId)) {
 
 			return ReflectionTestUtil.invoke(
 				DBPartitionMigrationValidator.class, "_write",

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/MethodNamingCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/MethodNamingCheck.java
@@ -46,7 +46,7 @@ public class MethodNamingCheck extends BaseCheck {
 		String className = JavaSourceUtil.getClassName(getAbsolutePath());
 
 		if (!className.equals("CentralizedThreadLocal")) {
-			_checkSetSafeCloseableName(detailAST, methodName);
+			_checkSetWithSafeCloseableMethodName(detailAST, methodName);
 		}
 
 		if (AnnotationUtil.containsAnnotation(detailAST, "Override")) {
@@ -192,7 +192,7 @@ public class MethodNamingCheck extends BaseCheck {
 		}
 	}
 
-	private void _checkSetSafeCloseableName(
+	private void _checkSetWithSafeCloseableMethodName(
 		DetailAST detailAST, String methodName) {
 
 		String typeName = getTypeName(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/MethodNamingCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/MethodNamingCheck.java
@@ -42,6 +42,8 @@ public class MethodNamingCheck extends BaseCheck {
 			_checkSearchMethodName(detailAST, methodName);
 		}
 
+		_checkSetSafeCloseableName(detailAST, methodName);
+
 		if (AnnotationUtil.containsAnnotation(detailAST, "Override")) {
 			return;
 		}
@@ -185,6 +187,25 @@ public class MethodNamingCheck extends BaseCheck {
 		}
 	}
 
+	private void _checkSetSafeCloseableName(
+		DetailAST detailAST, String methodName) {
+
+		String typeName = getTypeName(
+			detailAST.findFirstToken(TokenTypes.TYPE), false);
+
+		if (!typeName.equals("SafeCloseable") ||
+			!methodName.startsWith("set")) {
+
+			return;
+		}
+
+		if (!methodName.matches("set.+WithSafeCloseable\\d*")) {
+			log(
+				detailAST, _MSG_INCORRECT_SET_SAFE_CLOSEABLE_METHOD,
+				methodName);
+		}
+	}
+
 	private void _checkTypeName(DetailAST detailAST, String methodName) {
 		String absolutePath = getAbsolutePath();
 
@@ -246,6 +267,9 @@ public class MethodNamingCheck extends BaseCheck {
 
 	private static final String _MSG_INCORRECT_SEARCH_METHOD =
 		"search.method.incorrect";
+
+	private static final String _MSG_INCORRECT_SET_SAFE_CLOSEABLE_METHOD =
+		"set.safe.closeable.method.incorrect";
 
 	private static final String _MSG_RENAME_METHOD = "method.rename";
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/MethodNamingCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/MethodNamingCheck.java
@@ -45,7 +45,9 @@ public class MethodNamingCheck extends BaseCheck {
 
 		String className = JavaSourceUtil.getClassName(getAbsolutePath());
 
-		if (!className.equals("CentralizedThreadLocal")) {
+		if (isAttributeValue(_CHECK_SET_WITH_SAFE_CLOSEABLE_METHOD_NAMES) &&
+			!className.equals("CentralizedThreadLocal")) {
+
 			_checkSetWithSafeCloseableMethodName(detailAST, methodName);
 		}
 
@@ -260,6 +262,9 @@ public class MethodNamingCheck extends BaseCheck {
 
 	private static final String _CHECK_SEARCH_METHOD_NAMES =
 		"checkSearchMethodNames";
+
+	private static final String _CHECK_SET_WITH_SAFE_CLOSEABLE_METHOD_NAMES =
+		"checkSetWithSafeCloseableMethodNames";
 
 	private static final String _ENFORCE_TYPE_NAMES_KEY = "enforceTypeNames";
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/MethodNamingCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/MethodNamingCheck.java
@@ -8,6 +8,7 @@ package com.liferay.source.formatter.checkstyle.check;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TextFormatter;
+import com.liferay.source.formatter.check.util.JavaSourceUtil;
 
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -42,7 +43,11 @@ public class MethodNamingCheck extends BaseCheck {
 			_checkSearchMethodName(detailAST, methodName);
 		}
 
-		_checkSetSafeCloseableName(detailAST, methodName);
+		String className = JavaSourceUtil.getClassName(getAbsolutePath());
+
+		if (!className.equals("CentralizedThreadLocal")) {
+			_checkSetSafeCloseableName(detailAST, methodName);
+		}
 
 		if (AnnotationUtil.containsAnnotation(detailAST, "Override")) {
 			return;

--- a/modules/util/source-formatter/src/main/resources/checkstyle.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle.xml
@@ -579,6 +579,7 @@
 			<message key="method.incorrect.ending" value="Name of method returning type ''{0}'' should end with ''{1}''" />
 			<message key="method.rename" value="Rename method ''{0}'' to ''{1}''" />
 			<message key="search.method.incorrect" value="Incorrect name of method ''{0}''. Name should equal ''search'' or start with ''searchBy''." />
+			<message key="set.safe.closeable.method.incorrect" value="Incorrect name of method ''{0}''. Name should include the context and end with ''WithSafeCloseable''." />
 			<property name="enforceTypeNames" value="" />
 		</module>
 		<module name="com.liferay.source.formatter.checkstyle.check.MissingAuthorCheck">

--- a/portal-impl/src/com/liferay/portal/internal/increment/BufferedIncreasableEntry.java
+++ b/portal-impl/src/com/liferay/portal/internal/increment/BufferedIncreasableEntry.java
@@ -37,7 +37,7 @@ public class BufferedIncreasableEntry<K, T>
 	@Override
 	public BufferedIncreasableEntry<K, T> increase(Increment<T> deltaValue) {
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 					_companyId, _ctCollectionId)) {
 
 			return new BufferedIncreasableEntry<>(
@@ -50,7 +50,7 @@ public class BufferedIncreasableEntry<K, T>
 		_arguments[_arguments.length - 1] = getValue().getValue();
 
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 					_companyId, _ctCollectionId)) {
 
 			_aopMethodInvocation.proceed(_arguments);

--- a/portal-impl/src/com/liferay/portal/search/IndexableAdvice.java
+++ b/portal-impl/src/com/liferay/portal/search/IndexableAdvice.java
@@ -112,7 +112,8 @@ public class IndexableAdvice extends ChainableMethodAdvice {
 				}
 
 				try (SafeCloseable safeCloseable =
-						CompanyThreadLocal.setWithSafeCloseable(companyId)) {
+						CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+							companyId)) {
 
 					_reindex(curIndexer, indexableContext, arguments, result);
 				}

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -540,7 +540,8 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		validateWebId(webId);
 
 		SafeCloseable safeCloseable1 =
-			PortalInstances.setCopyInProcessCompanyId(fromCompanyId);
+			PortalInstances.setCopyInProcessCompanyIdWithSafeCloseable(
+				fromCompanyId);
 
 		try {
 			DBPartitionUtil.copyDBPartition(fromCompanyId, toCompanyId);
@@ -617,7 +618,8 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		try (SafeCloseable safeCloseable1 =
 				CompanyThreadLocal.setWithSafeCloseable(companyId);
 			SafeCloseable safeCloseable2 =
-				PortalInstances.setCompanyInDeletionProcess(companyId)) {
+				PortalInstances.setCompanyInDeletionProcessWithSafeCloseable(
+					companyId)) {
 
 			return doDeleteCompany(companyId);
 		}
@@ -666,7 +668,8 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 			companyId);
 
 		try (SafeCloseable safeCloseable2 =
-				PortalInstances.setCompanyInDeletionProcess(companyId)) {
+				PortalInstances.setCompanyInDeletionProcessWithSafeCloseable(
+					companyId)) {
 
 			_clearCompanyCache(companyId, true);
 			_clearVirtualHostCache(companyId);

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -366,8 +366,8 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 		DBPartitionUtil.insertDBPartition(companyId);
 
-		SafeCloseable safeCloseable = CompanyThreadLocal.setWithSafeCloseable(
-			companyId);
+		SafeCloseable safeCloseable =
+			CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId);
 
 		try {
 			return _transactionAwareInvoke(
@@ -552,8 +552,8 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 			throw throwable;
 		}
 
-		SafeCloseable safeCloseable2 = CompanyThreadLocal.setWithSafeCloseable(
-			toCompanyId);
+		SafeCloseable safeCloseable2 =
+			CompanyThreadLocal.setCompanyIdWithSafeCloseable(toCompanyId);
 
 		long companyId = toCompanyId;
 
@@ -616,7 +616,7 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		}
 
 		try (SafeCloseable safeCloseable1 =
-				CompanyThreadLocal.setWithSafeCloseable(companyId);
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId);
 			SafeCloseable safeCloseable2 =
 				PortalInstances.setCompanyInDeletionProcessWithSafeCloseable(
 					companyId)) {
@@ -664,8 +664,8 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 		Company company = companyPersistence.findByPrimaryKey(companyId);
 
-		SafeCloseable safeCloseable1 = CompanyThreadLocal.setWithSafeCloseable(
-			companyId);
+		SafeCloseable safeCloseable1 =
+			CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId);
 
 		try (SafeCloseable safeCloseable2 =
 				PortalInstances.setCompanyInDeletionProcessWithSafeCloseable(
@@ -772,7 +772,7 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 		for (Company company : companies) {
 			try (SafeCloseable safeCloseable =
-					CompanyThreadLocal.setWithSafeCloseable(
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 						company.getCompanyId())) {
 
 				unsafeConsumer.accept(company);
@@ -810,7 +810,8 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 		for (long companyId : companyIds) {
 			try (SafeCloseable safeCloseable =
-					CompanyThreadLocal.setWithSafeCloseable(companyId)) {
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+						companyId)) {
 
 				unsafeConsumer.accept(companyId);
 			}

--- a/portal-impl/src/com/liferay/portal/service/impl/VirtualHostLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/VirtualHostLocalServiceImpl.java
@@ -219,7 +219,7 @@ public class VirtualHostLocalServiceImpl
 				long virtualHostId = 0;
 
 				try (SafeCloseable safeCloseable =
-						CompanyThreadLocal.setWithSafeCloseable(
+						CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 							CompanyConstants.SYSTEM)) {
 
 					virtualHostId = counterLocalService.increment();

--- a/portal-impl/src/com/liferay/portal/servlet/filters/threadlocal/ThreadLocalFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/threadlocal/ThreadLocalFilter.java
@@ -35,7 +35,7 @@ public class ThreadLocalFilter
 		HttpServletRequest httpServletRequest,
 		HttpServletResponse httpServletResponse) {
 
-		ThreadLocalFilterThreadLocal.setFilterInvoked();
+		ThreadLocalFilterThreadLocal.setFilterInvokedWithSafeCloseable();
 
 		return null;
 	}

--- a/portal-impl/src/com/liferay/portal/servlet/filters/threadlocal/ThreadLocalFilterThreadLocal.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/threadlocal/ThreadLocalFilterThreadLocal.java
@@ -21,7 +21,9 @@ public class ThreadLocalFilterThreadLocal {
 		_filterInvoked.set(true);
 	}
 
-	public static SafeCloseable setFilterInvoked(boolean filterInvoked) {
+	public static SafeCloseable setFilterInvokedWithSafeCloseable(
+		boolean filterInvoked) {
+
 		return _filterInvoked.setWithSafeCloseable(filterInvoked);
 	}
 

--- a/portal-impl/src/com/liferay/portal/util/PortalInstances.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalInstances.java
@@ -60,8 +60,9 @@ public class PortalInstances {
 			UnsafeSupplier<Company, PortalException> unsafeSupplier)
 		throws PortalException {
 
-		try (SafeCloseable safeCloseable1 = SiteInitializerThreadLocal.setKey(
-				siteInitializerKey)) {
+		try (SafeCloseable safeCloseable1 =
+				SiteInitializerThreadLocal.setKeyWithSafeCloseable(
+					siteInitializerKey)) {
 
 			Company company = unsafeSupplier.get();
 

--- a/portal-impl/src/com/liferay/portal/util/PortalInstances.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalInstances.java
@@ -389,7 +389,9 @@ public class PortalInstances {
 		WebAppPool.remove(companyId, WebKeys.PORTLET_CATEGORY);
 	}
 
-	public static SafeCloseable setCompanyInDeletionProcess(long companyId) {
+	public static SafeCloseable setCompanyInDeletionProcessWithSafeCloseable(
+		long companyId) {
+
 		if (_companyIdsInDeletionProcess.contains(companyId)) {
 			throw new UnsupportedOperationException(
 				companyId + " is already in deletion");
@@ -400,7 +402,9 @@ public class PortalInstances {
 		return () -> _companyIdsInDeletionProcess.remove(companyId);
 	}
 
-	public static SafeCloseable setCopyInProcessCompanyId(long companyId) {
+	public static SafeCloseable setCopyInProcessCompanyIdWithSafeCloseable(
+		long companyId) {
+
 		if (_copyInProcessCompanyId != null) {
 			throw new UnsupportedOperationException(
 				"Company in process company ID is not null");

--- a/portal-impl/src/com/liferay/portal/util/PortalInstances.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalInstances.java
@@ -66,7 +66,7 @@ public class PortalInstances {
 			Company company = unsafeSupplier.get();
 
 			try (SafeCloseable safeCloseable2 =
-					CompanyThreadLocal.setWithSafeCloseable(
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 						company.getCompanyId())) {
 
 				initCompany(company, true);

--- a/portal-impl/src/com/liferay/portlet/admin/util/OmniadminUtil.java
+++ b/portal-impl/src/com/liferay/portlet/admin/util/OmniadminUtil.java
@@ -85,7 +85,7 @@ public class OmniadminUtil {
 			}
 
 			try (SafeCloseable safeCloseable =
-					CompanyThreadLocal.setWithSafeCloseable(
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 						PortalInstancePool.getDefaultCompanyId())) {
 
 				return RoleLocalServiceUtil.hasUserRole(

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
@@ -146,9 +146,10 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 				// Must do aop service call to go through service wrappers
 
 				try (SafeCloseable safeCloseable =
-						DeletedAssetObjectThreadLocal.setWithSafeCloseable(
-							assetEntry.getClassNameId(),
-							assetEntry.getClassPK())) {
+						DeletedAssetObjectThreadLocal.
+							setAssetObjectWithSafeCloseable(
+								assetEntry.getClassNameId(),
+								assetEntry.getClassPK())) {
 
 					assetEntryLocalService.deleteEntry(assetEntry);
 				}
@@ -1391,7 +1392,8 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 		// Social
 
 		try (SafeCloseable safeCloseable =
-				DeletedAssetEntryThreadLocal.setWithSafeCloseable(entry)) {
+				DeletedAssetEntryThreadLocal.setAssetEntryWithSafeCloseable(
+					entry)) {
 
 			SocialActivityManagerUtil.deleteActivities(entry);
 		}

--- a/portal-impl/src/com/liferay/portlet/asset/util/DeletedAssetEntryThreadLocal.java
+++ b/portal-impl/src/com/liferay/portlet/asset/util/DeletedAssetEntryThreadLocal.java
@@ -30,7 +30,9 @@ public class DeletedAssetEntryThreadLocal {
 		return false;
 	}
 
-	public static SafeCloseable setWithSafeCloseable(AssetEntry assetEntry) {
+	public static SafeCloseable setAssetEntryWithSafeCloseable(
+		AssetEntry assetEntry) {
+
 		return _assetEntryThreadLocal.setWithSafeCloseable(assetEntry);
 	}
 

--- a/portal-impl/src/com/liferay/portlet/asset/util/DeletedAssetObjectThreadLocal.java
+++ b/portal-impl/src/com/liferay/portlet/asset/util/DeletedAssetObjectThreadLocal.java
@@ -33,7 +33,7 @@ public class DeletedAssetObjectThreadLocal {
 		return false;
 	}
 
-	public static SafeCloseable setWithSafeCloseable(
+	public static SafeCloseable setAssetObjectWithSafeCloseable(
 		long classNameId, long classPK) {
 
 		return _assetObjectThreadLocal.setWithSafeCloseable(

--- a/portal-impl/test/unit/com/liferay/portal/internal/increment/BufferedIncrementRunnableTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/internal/increment/BufferedIncrementRunnableTest.java
@@ -105,7 +105,7 @@ public class BufferedIncrementRunnableTest {
 		long companyId) {
 
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(companyId)) {
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId)) {
 
 			return new BufferedIncreasableEntry(
 				_createTestMethodInvocation(

--- a/portal-kernel/src/com/liferay/portal/kernel/cluster/ClusterInvokeThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/cluster/ClusterInvokeThreadLocal.java
@@ -21,7 +21,7 @@ public class ClusterInvokeThreadLocal {
 		_enabled.set(enabled);
 	}
 
-	public static SafeCloseable setWithSafeCloseable(boolean enabled) {
+	public static SafeCloseable setEnabledWithSafeCloseable(boolean enabled) {
 		return _enabled.setWithSafeCloseable(enabled);
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/orm/DefaultActionableDynamicQuery.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/orm/DefaultActionableDynamicQuery.java
@@ -285,8 +285,9 @@ public class DefaultActionableDynamicQuery implements ActionableDynamicQuery {
 						executorService.submit(
 							() -> {
 								try (SafeCloseable safeCloseable =
-										CompanyThreadLocal.setWithSafeCloseable(
-											companyId)) {
+										CompanyThreadLocal.
+											setCompanyIdWithSafeCloseable(
+												companyId)) {
 
 									performAction(object);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/feature/flag/FeatureFlagManagerUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/feature/flag/FeatureFlagManagerUtil.java
@@ -39,7 +39,8 @@ public class FeatureFlagManagerUtil {
 				}
 
 				try (SafeCloseable safeCloseable =
-						CompanyThreadLocal.setWithSafeCloseable(companyId)) {
+						CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+							companyId)) {
 
 					return GetterUtil.getBoolean(
 						PropsUtil.get("feature.flag." + key));

--- a/portal-kernel/src/com/liferay/portal/kernel/increment/BufferedIncrementThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/increment/BufferedIncrementThreadLocal.java
@@ -17,7 +17,9 @@ public class BufferedIncrementThreadLocal {
 		return _forceSync.get();
 	}
 
-	public static SafeCloseable setWithSafeCloseable(boolean forceSync) {
+	public static SafeCloseable setForceSyncWithSafeCloseable(
+		boolean forceSync) {
+
 		return _forceSync.setWithSafeCloseable(forceSync);
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
@@ -178,29 +178,12 @@ public class CompanyThreadLocal {
 		CTCollectionThreadLocal.removeCTCollectionId();
 	}
 
-	public static SafeCloseable setInitializingCompanyIdWithSafeCloseable(
-		long companyId) {
-
-		if (companyId > 0) {
-			return _companyId.setWithSafeCloseable(companyId);
-		}
-
-		return _companyId.setWithSafeCloseable(CompanyConstants.SYSTEM);
-	}
-
-	public static SafeCloseable setInitializingPortalInstance(
-		boolean initializingPortalInstance) {
-
-		return _initializingPortalInstance.setWithSafeCloseable(
-			initializingPortalInstance);
-	}
-
-	public static SafeCloseable setWithSafeCloseable(Long companyId) {
-		return setWithSafeCloseable(
+	public static SafeCloseable setCompanyIdWithSafeCloseable(Long companyId) {
+		return setCompanyIdWithSafeCloseable(
 			companyId, CTCollectionThreadLocal.CT_COLLECTION_ID_PRODUCTION);
 	}
 
-	public static SafeCloseable setWithSafeCloseable(
+	public static SafeCloseable setCompanyIdWithSafeCloseable(
 		Long companyId, Long ctCollectionId) {
 
 		List<SafeCloseable> safeCloseables = new ArrayList<>();
@@ -246,6 +229,23 @@ public class CompanyThreadLocal {
 				safeCloseable.close();
 			}
 		};
+	}
+
+	public static SafeCloseable setInitializingCompanyIdWithSafeCloseable(
+		long companyId) {
+
+		if (companyId > 0) {
+			return _companyId.setWithSafeCloseable(companyId);
+		}
+
+		return _companyId.setWithSafeCloseable(CompanyConstants.SYSTEM);
+	}
+
+	public static SafeCloseable setInitializingPortalInstanceWithSafeCloseable(
+		boolean initializingPortalInstance) {
+
+		return _initializingPortalInstance.setWithSafeCloseable(
+			initializingPortalInstance);
 	}
 
 	private static void _clearUserThreadLocals() {

--- a/portal-kernel/src/com/liferay/site/initializer/kernel/util/SiteInitializerThreadLocal.java
+++ b/portal-kernel/src/com/liferay/site/initializer/kernel/util/SiteInitializerThreadLocal.java
@@ -17,7 +17,7 @@ public class SiteInitializerThreadLocal {
 		return _key.get();
 	}
 
-	public static SafeCloseable setKey(String key) {
+	public static SafeCloseable setKeyWithSafeCloseable(String key) {
 		return _key.setWithSafeCloseable(key);
 	}
 

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/dao/orm/DefaultActionableDynamicQueryTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/dao/orm/DefaultActionableDynamicQueryTest.java
@@ -100,7 +100,8 @@ public class DefaultActionableDynamicQueryTest {
 		long expectedCompanyId = 1L;
 
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(expectedCompanyId)) {
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					expectedCompanyId)) {
 
 			DefaultActionableDynamicQuery defaultActionableDynamicQuery =
 				new DefaultActionableDynamicQuery() {

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/auth/CompanyThreadLocalTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/auth/CompanyThreadLocalTest.java
@@ -48,7 +48,7 @@ public class CompanyThreadLocalTest {
 
 	@Test
 	public void testLockWithSetWithSafeCloseable() {
-		_testLock(CompanyThreadLocal::setWithSafeCloseable);
+		_testLock(CompanyThreadLocal::setCompanyIdWithSafeCloseable);
 	}
 
 	@Test
@@ -59,7 +59,7 @@ public class CompanyThreadLocalTest {
 		TimeZoneThreadLocal.setDefaultTimeZone(pstTimeZone);
 
 		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(1L)) {
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(1L)) {
 
 			Assert.assertNotEquals(
 				LocaleUtil.GERMAN, LocaleThreadLocal.getDefaultLocale());

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/SynchronousDestinationTestRule.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/SynchronousDestinationTestRule.java
@@ -168,7 +168,8 @@ public class SynchronousDestinationTestRule
 				tensorflowModelDownloadFilter, videoProcessorFilter);
 
 			_bufferedIncrementForceSyncSafeCloseable =
-				BufferedIncrementThreadLocal.setWithSafeCloseable(true);
+				BufferedIncrementThreadLocal.setForceSyncWithSafeCloseable(
+					true);
 
 			replaceDestination(DestinationNames.ASYNC_SERVICE);
 			replaceDestination(DestinationNames.BACKGROUND_TASK);

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -262,6 +262,8 @@
 
     checkstyle.MethodNamingCheck.checkSearchMethodNames=true
 
+    checkstyle.MethodNamingCheck.checkSetWithSafeCloseableMethodNames=true
+
     checkstyle.MethodNamingCheck.enforceTypeNames=\
         (Double|Int|Long)Stream,\
         (Http|HttpServlet|LiferayPortlet|Render|Search|Servlet)(Request|Response),\


### PR DESCRIPTION
```
     [java] java.lang.Exception: Found 23 formatting issues:
     [java] 1: Incorrect name of method 'setWithSafeCloseable'. Name should include the context and end with 'WithSafeCloseable'.: ./modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/util/AllowEditAccountRoleThreadLocal.java 28 (Checkstyle:MethodNamingCheck)
     [java] 2: Incorrect name of method 'setWithSafeCloseable'. Name should include the context and end with 'WithSafeCloseable'.: ./modules/apps/account/account-api/src/main/java/com/liferay/account/role/AccountRolePermissionThreadLocal.java 25 (Checkstyle:MethodNamingCheck)
     [java] 3: Incorrect name of method 'setWithSafeCloseable'. Name should include the context and end with 'WithSafeCloseable'.: ./modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/context/CommerceContextThreadLocal.java 24 (Checkstyle:MethodNamingCheck)
     [java] 4: Incorrect name of method 'setWithSafeCloseable'. Name should include the context and end with 'WithSafeCloseable'.: ./modules/apps/commerce/commerce-api/src/main/java/com/liferay/commerce/context/CommerceGroupThreadLocal.java 26 (Checkstyle:MethodNamingCheck)
     [java] 5: Incorrect name of method 'setWithSafeCloseable'. Name should include the context and end with 'WithSafeCloseable'.: ./modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/UpdateLayoutStatusThreadLocal.java 20 (Checkstyle:MethodNamingCheck)
     [java] 6: Incorrect name of method 'setWithSafeCloseable'. Name should include the context and end with 'WithSafeCloseable'.: ./modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/util/CheckUnlockedLayoutThreadLocal.java 20 (Checkstyle:MethodNamingCheck)
     [java] 7: Incorrect name of method 'setDeleteObjectDefinitionId'. Name should include the context and end with 'WithSafeCloseable'.: ./modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionThreadLocal.java 30 (Checkstyle:MethodNamingCheck)
     [java] 8: Incorrect name of method 'setStrictObjectReindex'. Name should include the context and end with 'WithSafeCloseable'.: ./modules/apps/object/object-api/src/main/java/com/liferay/object/search/StrictObjectReindexThreadLocal.java 20 (Checkstyle:MethodNamingCheck)
     [java] 9: Incorrect name of method 'setInExecution'. Name should include the context and end with 'WithSafeCloseable'.: ./modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/BackgroundTaskInExecutionUtil.java 23 (Checkstyle:MethodNamingCheck)
     [java] 10: Incorrect name of method 'setWithSafeCloseable'. Name should include the context and end with 'WithSafeCloseable'.: ./modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/internal/provider/PLOOriginalTranslationThreadLocal.java 28 (Checkstyle:MethodNamingCheck)
     [java] 11: Incorrect name of method 'setBatchInstallInProcess'. Name should include the context and end with 'WithSafeCloseable'.: ./modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGBatchInstallThreadLocal.java 20 (Checkstyle:MethodNamingCheck)
     [java] 12: Incorrect name of method 'setWithSafeCloseable'. Name should include the context and end with 'WithSafeCloseable'.: ./modules/core/petra/petra-lang/src/main/java/com/liferay/petra/lang/CentralizedThreadLocal.java 185 (Checkstyle:MethodNamingCheck)
     [java] 13: Incorrect name of method 'setFilterInvoked'. Name should include the context and end with 'WithSafeCloseable'.: ./portal-impl/src/com/liferay/portal/servlet/filters/threadlocal/ThreadLocalFilterThreadLocal.java 24 (Checkstyle:MethodNamingCheck)
     [java] 14: Incorrect name of method 'setCompanyInDeletionProcess'. Name should include the context and end with 'WithSafeCloseable'.: ./portal-impl/src/com/liferay/portal/util/PortalInstances.java 392 (Checkstyle:MethodNamingCheck)
     [java] 15: Incorrect name of method 'setCopyInProcessCompanyId'. Name should include the context and end with 'WithSafeCloseable'.: ./portal-impl/src/com/liferay/portal/util/PortalInstances.java 403 (Checkstyle:MethodNamingCheck)
     [java] 16: Incorrect name of method 'setWithSafeCloseable'. Name should include the context and end with 'WithSafeCloseable'.: ./portal-impl/src/com/liferay/portlet/asset/util/DeletedAssetEntryThreadLocal.java 33 (Checkstyle:MethodNamingCheck)
     [java] 17: Incorrect name of method 'setWithSafeCloseable'. Name should include the context and end with 'WithSafeCloseable'.: ./portal-impl/src/com/liferay/portlet/asset/util/DeletedAssetObjectThreadLocal.java 36 (Checkstyle:MethodNamingCheck)
     [java] 18: Incorrect name of method 'setWithSafeCloseable'. Name should include the context and end with 'WithSafeCloseable'.: ./portal-kernel/src/com/liferay/portal/kernel/cluster/ClusterInvokeThreadLocal.java 24 (Checkstyle:MethodNamingCheck)
     [java] 19: Incorrect name of method 'setWithSafeCloseable'. Name should include the context and end with 'WithSafeCloseable'.: ./portal-kernel/src/com/liferay/portal/kernel/increment/BufferedIncrementThreadLocal.java 20 (Checkstyle:MethodNamingCheck)
     [java] 20: Incorrect name of method 'setInitializingPortalInstance'. Name should include the context and end with 'WithSafeCloseable'.: ./portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java 191 (Checkstyle:MethodNamingCheck)
     [java] 21: Incorrect name of method 'setWithSafeCloseable'. Name should include the context and end with 'WithSafeCloseable'.: ./portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java 198 (Checkstyle:MethodNamingCheck)
     [java] 22: Incorrect name of method 'setWithSafeCloseable'. Name should include the context and end with 'WithSafeCloseable'.: ./portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java 203 (Checkstyle:MethodNamingCheck)
     [java] 23: Incorrect name of method 'setKey'. Name should include the context and end with 'WithSafeCloseable'.: ./portal-kernel/src/com/liferay/site/initializer/kernel/util/SiteInitializerThreadLocal.java 20 (Checkstyle:MethodNamingCheck)

```