### PR TITLE
LPD-40723 Rework initial SF rule to account for the <liferay-ui:csp> tag

### DIFF
--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export_import_process.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export_import_process.jsp
@@ -136,11 +136,11 @@ if (Validator.isNotNull(backURL)) {
 
 			<c:if test="<%= Validator.isNotNull(curBackgroundTask.getStatusMessage()) %>">
 				<div class="background-task-status-row h6">
-					<liferay:csp>
+					<liferay-ui:csp>
 						<a class="details-link" href="javascript:void(0);" onclick="<portlet:namespace />viewBackgroundTaskDetails(<%= curBackgroundTask.getBackgroundTaskId() %>);">
 							<liferay-ui:message key="see-more-details" />
 						</a>
-					</liferay:csp>
+					</liferay-ui:csp>
 				</div>
 
 				<div class="background-task-status-message hide" id="<portlet:namespace />backgroundTaskStatusMessage<%= curBackgroundTask.getBackgroundTaskId() %>">

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/CSPComplianceCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/CSPComplianceCheck.java
@@ -43,16 +43,22 @@ public class CSPComplianceCheck extends BaseTagAttributesCheck {
 		String lowerCaseContent) {
 
 		List<String> ignoredTagPrefixes = new ArrayList<>();
+		String liferayUiCspTagOpen = StringPool.BLANK;
+		String liferayUiCspTagClose = StringPool.BLANK;
 
 		if (fileName.endsWith(".ftl")) {
 			ignoredTagPrefixes = getAttributeValues(
 				_IGNORED_FTL_TAG_PREFIXES_KEY, absolutePath);
+			liferayUiCspTagOpen = "<@liferay_ui.csp>";
+			liferayUiCspTagClose = "</@liferay_ui.csp>";
 		}
 		else if (fileName.endsWith(".jsp") || fileName.endsWith(".jspf") ||
 				 fileName.endsWith(".jspx")) {
 
 			ignoredTagPrefixes = getAttributeValues(
 				_IGNORED_JSP_TAG_PREFIXES_KEY, absolutePath);
+			liferayUiCspTagOpen = "<liferay-ui:csp>";
+			liferayUiCspTagClose = "</liferay-ui:csp>";
 		}
 
 		if (ListUtil.isEmpty(ignoredTagPrefixes)) {
@@ -97,6 +103,15 @@ public class CSPComplianceCheck extends BaseTagAttributesCheck {
 					if (tagString.startsWith(ignoredTagPrefix)) {
 						continue outerLoop;
 					}
+				}
+
+				String previousPart = content.substring(0, tagStartPosition);
+
+				int y = previousPart.lastIndexOf(liferayUiCspTagClose);
+				int z = previousPart.lastIndexOf(liferayUiCspTagOpen);
+
+				if (z > y) {
+					continue outerLoop;
 				}
 
 				addMessage(

--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -220,7 +220,6 @@
 		<check name="CSPComplianceCheck">
 			<category name="Bug Prevention" />
 			<description name="Checks code to prevent common CSP related pitfalls." />
-			<property name="enabled" value="false" />
 		</check>
 		<check name="FTLEmptyLinesCheck">
 			<category name="Styling" />
@@ -1091,7 +1090,6 @@
 		<check name="CSPComplianceCheck">
 			<category name="Bug Prevention" />
 			<description name="Checks code to prevent common CSP related pitfalls." />
-			<property name="enabled" value="false" />
 		</check>
 		<check name="EmptyCollectionCheck">
 			<category name="Styling" />


### PR DESCRIPTION
Hey Alan, this is a change in the `CSPComplianceCheck` to prevent it from triggering when onclick, onchange, ... attributes appear in an HTML element contained inside a `<liferay-ui:csp>` tag.

I'm also activating the rule and fixing some violations due to incorrect changes in previous PRs.

Feel free to forward it to Brian if you see everything fits :+1: 

Thx