### PR TITLE
LPD-45318 Check variable name by ReflectionTestUtil.getAndSetFieldValue

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/AppendCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/AppendCheck.java
@@ -38,16 +38,20 @@ public class AppendCheck extends BaseStringConcatenationCheck {
 				continue;
 			}
 
-			DetailAST parameterDetailAST = getParameterDetailAST(
-				methodCallDetailAST);
+			DetailAST methodCallFirstParameterExprDetailAST =
+				getFirstParameterExprDetailAST(methodCallDetailAST);
 
-			if (parameterDetailAST == null) {
+			if (methodCallFirstParameterExprDetailAST == null) {
 				continue;
 			}
 
-			_checkPlusOperator(parameterDetailAST);
+			DetailAST methodCallFirstParameterDetailAST =
+				methodCallFirstParameterExprDetailAST.getFirstChild();
 
-			if ((parameterDetailAST.getType() != TokenTypes.STRING_LITERAL) ||
+			_checkPlusOperator(methodCallFirstParameterDetailAST);
+
+			if ((methodCallFirstParameterDetailAST.getType() !=
+					TokenTypes.STRING_LITERAL) ||
 				_containsMethodCall(
 					detailAST, variableName, "setIndex", "setStringAt")) {
 
@@ -66,21 +70,26 @@ public class AppendCheck extends BaseStringConcatenationCheck {
 					continue;
 				}
 
-				DetailAST nextParameterDetailAST = getParameterDetailAST(
-					nextMethodCallDetailAST);
+				DetailAST nextMethodCallFirstParameterExprDetailAST =
+					getFirstParameterExprDetailAST(nextMethodCallDetailAST);
 
-				if (nextParameterDetailAST != null) {
-					if (nextParameterDetailAST.getType() ==
+				if (nextMethodCallFirstParameterExprDetailAST != null) {
+					DetailAST nextMethodCallFirstParameterDetailAST =
+						nextMethodCallFirstParameterExprDetailAST.
+							getFirstChild();
+
+					if (nextMethodCallFirstParameterDetailAST.getType() ==
 							TokenTypes.STRING_LITERAL) {
 
 						_checkLiteralStrings(
 							methodCallDetailAST, nextMethodCallDetailAST,
-							parameterDetailAST.getText(),
-							nextParameterDetailAST.getText());
+							methodCallFirstParameterDetailAST.getText(),
+							nextMethodCallFirstParameterDetailAST.getText());
 					}
 					else {
 						checkCombineOperand(
-							parameterDetailAST, nextParameterDetailAST);
+							methodCallFirstParameterDetailAST,
+							nextMethodCallFirstParameterDetailAST);
 					}
 				}
 			}
@@ -100,15 +109,22 @@ public class AppendCheck extends BaseStringConcatenationCheck {
 				continue;
 			}
 
-			DetailAST previousParameterDetailAST = getParameterDetailAST(
-				previousMethodCallDetailAST);
+			DetailAST previousMethodCallFirstParameterExprDetailAST =
+				getFirstParameterExprDetailAST(previousMethodCallDetailAST);
 
-			if ((previousParameterDetailAST != null) &&
-				(previousParameterDetailAST.getType() !=
-					TokenTypes.STRING_LITERAL)) {
+			if (previousMethodCallFirstParameterExprDetailAST == null) {
+				continue;
+			}
+
+			DetailAST previousMethodCallFirstParameterDetailAST =
+				previousMethodCallFirstParameterExprDetailAST.getFirstChild();
+
+			if (previousMethodCallFirstParameterDetailAST.getType() !=
+					TokenTypes.STRING_LITERAL) {
 
 				checkCombineOperand(
-					parameterDetailAST, previousParameterDetailAST);
+					methodCallFirstParameterDetailAST,
+					previousMethodCallFirstParameterDetailAST);
 			}
 		}
 	}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/BaseCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/BaseCheck.java
@@ -350,6 +350,19 @@ public abstract class BaseCheck extends AbstractCheck {
 		return endLineNumber;
 	}
 
+	protected DetailAST getFirstParameterExprDetailAST(
+		DetailAST methodCallDetailAST) {
+
+		List<DetailAST> parameterExprDetailASTList =
+			getParameterExprDetailASTList(methodCallDetailAST);
+
+		if (parameterExprDetailASTList.isEmpty()) {
+			return null;
+		}
+
+		return parameterExprDetailASTList.get(0);
+	}
+
 	protected String getFullyQualifiedTypeName(
 		DetailAST typeDetailAST, boolean checkPackage) {
 
@@ -606,18 +619,13 @@ public abstract class BaseCheck extends AbstractCheck {
 			parametersDetailAST, false, TokenTypes.PARAMETER_DEF);
 	}
 
-	protected DetailAST getParameterDetailAST(DetailAST methodCallDetailAST) {
+	protected List<DetailAST> getParameterExprDetailASTList(
+		DetailAST methodCallDetailAST) {
+
 		DetailAST elistDetailAST = methodCallDetailAST.findFirstToken(
 			TokenTypes.ELIST);
 
-		DetailAST exprDetailAST = elistDetailAST.findFirstToken(
-			TokenTypes.EXPR);
-
-		if (exprDetailAST == null) {
-			return null;
-		}
-
-		return exprDetailAST.getFirstChild();
+		return getAllChildTokens(elistDetailAST, false, TokenTypes.EXPR);
 	}
 
 	protected List<String> getParameterNames(DetailAST detailAST) {

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/BaseUnnecessaryStatementCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/BaseUnnecessaryStatementCheck.java
@@ -204,9 +204,14 @@ public abstract class BaseUnnecessaryStatementCheck extends BaseCheck {
 
 		String methodName = getMethodName(methodCallDetailAST);
 
-		if (!methodName.equals("toString") ||
-			(getParameterDetailAST(methodCallDetailAST) != null)) {
+		if (!methodName.equals("toString")) {
+			return;
+		}
 
+		List<DetailAST> parameterExprDetailASTList =
+			getParameterExprDetailASTList(methodCallDetailAST);
+
+		if (!parameterExprDetailASTList.isEmpty()) {
 			return;
 		}
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/ExceptionPrintStackTraceCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/ExceptionPrintStackTraceCheck.java
@@ -55,14 +55,12 @@ public class ExceptionPrintStackTraceCheck extends BaseCheck {
 		}
 
 		for (DetailAST methodCallDetailAST : methodCallDetailASTList) {
-			DetailAST parameterDetailAST = getParameterDetailAST(
-				methodCallDetailAST);
+			List<DetailAST> parameterExprDetailASTList =
+				getParameterExprDetailASTList(methodCallDetailAST);
 
-			if (parameterDetailAST != null) {
-				continue;
+			if (parameterExprDetailASTList.isEmpty()) {
+				log(methodCallDetailAST, _MSG_AVOID_METHOD_CALL);
 			}
-
-			log(methodCallDetailAST, _MSG_AVOID_METHOD_CALL);
 		}
 	}
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/LambdaCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/LambdaCheck.java
@@ -8,6 +8,8 @@ package com.liferay.source.formatter.checkstyle.check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
+import java.util.List;
+
 /**
  * @author Hugo Huijser
  */
@@ -48,10 +50,10 @@ public class LambdaCheck extends BaseCheck {
 				return;
 			}
 
-			DetailAST parameterDetailAST = getParameterDetailAST(
-				firstChildDetailAST);
+			List<DetailAST> parameterExprDetailASTList =
+				getParameterExprDetailASTList(firstChildDetailAST);
 
-			if (parameterDetailAST != null) {
+			if (!parameterExprDetailASTList.isEmpty()) {
 				return;
 			}
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/MissingEmptyLineCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/MissingEmptyLineCheck.java
@@ -354,9 +354,11 @@ public class MissingEmptyLineCheck extends BaseCheck {
 					getAttributeValues(_ENFORCE_EMPTY_LINE_BEFORE_METHOD_NAMES);
 
 				String methodName = getMethodName(detailAST);
+				List<DetailAST> parameterExprDetailASTList =
+					getParameterExprDetailASTList(detailAST);
 
 				if (enforceEmptyLineBeforeMethodNames.contains(methodName) &&
-					Validator.isNull(getParameterDetailAST(detailAST))) {
+					parameterExprDetailASTList.isEmpty()) {
 
 					log(
 						startLineNumber,

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/ThreadContextClassLoaderCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/ThreadContextClassLoaderCheck.java
@@ -85,15 +85,22 @@ public class ThreadContextClassLoaderCheck extends BaseCheck {
 					contextClassLoaderVariableDefDetailAST);
 			}
 			else if (Objects.equals(methodName, "setContextClassLoader")) {
-				DetailAST parameterDetailAST = getParameterDetailAST(
-					parentDetailAST);
+				DetailAST firstParameterExprDetailAST =
+					getFirstParameterExprDetailAST(parentDetailAST);
+
+				if (firstParameterExprDetailAST == null) {
+					continue;
+				}
+
+				DetailAST firstChildDetailAST =
+					firstParameterExprDetailAST.getFirstChild();
 
 				if (Objects.equals(
 						contextClassLoaderVariableName,
-						parameterDetailAST.getText())) {
+						firstChildDetailAST.getText())) {
 
 					log(
-						parameterDetailAST,
+						firstChildDetailAST,
 						_MSG_THREAD_CONTEXT_CLASS_LOADER_UTIL_USE);
 				}
 			}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/URLInputStreamCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/URLInputStreamCheck.java
@@ -64,10 +64,17 @@ public class URLInputStreamCheck extends BaseCheck {
 			}
 		}
 
-		DetailAST parameterDetailAST = getParameterDetailAST(
+		DetailAST firstParameterExprDetailAST = getFirstParameterExprDetailAST(
 			methodCallDetailAST);
 
-		if (_isURLOpenStream(parameterDetailAST)) {
+		if (firstParameterExprDetailAST == null) {
+			return;
+		}
+
+		DetailAST firstChildDetailAST =
+			firstParameterExprDetailAST.getFirstChild();
+
+		if (_isURLOpenStream(firstChildDetailAST)) {
 			String actualUsage = StringBundler.concat(
 				variableName, StringPool.PERIOD, methodName,
 				StringPool.OPEN_PARENTHESIS, StringPool.CLOSE_PARENTHESIS);
@@ -76,10 +83,10 @@ public class URLInputStreamCheck extends BaseCheck {
 				methodCallDetailAST, _MSG_REPLACE_USAGE, expectedUsage,
 				actualUsage);
 		}
-		else if (parameterDetailAST.getType() == TokenTypes.IDENT) {
+		else if (firstChildDetailAST.getType() == TokenTypes.IDENT) {
 			DetailAST parameterDefinitionDetailAST =
 				getVariableDefinitionDetailAST(
-					parameterDetailAST, parameterDetailAST.getText());
+					firstChildDetailAST, firstChildDetailAST.getText());
 
 			if ((parameterDefinitionDetailAST == null) ||
 				!Objects.equals(
@@ -99,7 +106,7 @@ public class URLInputStreamCheck extends BaseCheck {
 			DetailAST exprDetailAST = assignDetailAST.findFirstToken(
 				TokenTypes.EXPR);
 
-			DetailAST firstChildDetailAST = exprDetailAST.getFirstChild();
+			firstChildDetailAST = exprDetailAST.getFirstChild();
 
 			if (_isURLOpenStream(firstChildDetailAST)) {
 				String actualUsage = StringBundler.concat(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/VariableNameCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/VariableNameCheck.java
@@ -51,8 +51,6 @@ public class VariableNameCheck extends BaseCheck {
 
 		if (detailAST.getType() == TokenTypes.VARIABLE_DEF) {
 			_checkClassNameVariable(detailAST, name);
-			_checkByMethod(
-				detailAST, name, "ReflectionTestUtil", "getAndSetFieldValue");
 			_checkTypo(detailAST, name);
 		}
 
@@ -119,74 +117,6 @@ public class VariableNameCheck extends BaseCheck {
 	}
 
 	protected static final String MSG_RENAME_VARIABLE = "variable.rename";
-
-	private void _checkByMethod(
-		DetailAST detailAST, String variableName, String className,
-		String methodName) {
-
-		DetailAST assignDetailAST = detailAST.findFirstToken(TokenTypes.ASSIGN);
-
-		if (assignDetailAST == null) {
-			return;
-		}
-
-		DetailAST firstChildDetailAST = assignDetailAST.getFirstChild();
-
-		if (firstChildDetailAST.getType() != TokenTypes.EXPR) {
-			return;
-		}
-
-		firstChildDetailAST = firstChildDetailAST.getFirstChild();
-
-		if (firstChildDetailAST.getType() != TokenTypes.METHOD_CALL) {
-			return;
-		}
-
-		firstChildDetailAST = firstChildDetailAST.getFirstChild();
-
-		if (firstChildDetailAST.getType() != TokenTypes.DOT) {
-			return;
-		}
-
-		List<String> names = getNames(firstChildDetailAST, false);
-
-		if ((names.size() != 2) && (names.size() != 3)) {
-			return;
-		}
-
-		String methodCallClassName = names.get(0);
-		String methodCallMethodName = names.get(1);
-
-		if (StringUtil.equals(className, methodCallClassName) &&
-			StringUtil.equals(methodName, methodCallMethodName)) {
-
-			List<DetailAST> parameterExprDetailASTList =
-				getParameterExprDetailASTList(firstChildDetailAST.getParent());
-
-			if (parameterExprDetailASTList.size() <= 2) {
-				return;
-			}
-
-			DetailAST exprDetailAST = parameterExprDetailASTList.get(1);
-
-			firstChildDetailAST = exprDetailAST.getFirstChild();
-
-			if (firstChildDetailAST.getType() != TokenTypes.STRING_LITERAL) {
-				return;
-			}
-
-			String expectedVariableName = _getExpectedVariableName(
-				firstChildDetailAST.getText());
-
-			if (!variableName.matches(
-					"(?i).*" + expectedVariableName + "[0-9]*")) {
-
-				log(
-					detailAST, _MSG_INCORRECT_ENDING_VARIABLE_2, variableName,
-					expectedVariableName);
-			}
-		}
-	}
 
 	private void _checkClassNameVariable(
 		DetailAST detailAST, String variableName) {
@@ -815,6 +745,10 @@ public class VariableNameCheck extends BaseCheck {
 					continue;
 				}
 
+				_checkVariableNameByMethodCall(
+					firstChildDetailAST, variableName, "ReflectionTestUtil",
+					"getAndSetFieldValue");
+
 				methodName = getMethodName(firstChildDetailAST);
 
 				if (methodName.equals("stream")) {
@@ -836,15 +770,73 @@ public class VariableNameCheck extends BaseCheck {
 				DetailAST nextSiblingDetailAST =
 					firstChildDetailAST.getNextSibling();
 
-				if (nextSiblingDetailAST.getType() == TokenTypes.METHOD_CALL) {
-					methodName = getMethodName(nextSiblingDetailAST);
+				if (nextSiblingDetailAST.getType() != TokenTypes.METHOD_CALL) {
+					continue;
 				}
+
+				_checkVariableNameByMethodCall(
+					nextSiblingDetailAST, variableName, "ReflectionTestUtil",
+					"getAndSetFieldValue");
+
+				methodName = getMethodName(nextSiblingDetailAST);
 
 				if (methodName.matches("get[A-Z].*")) {
 					_checkTypo(
 						detailAST, variableName, methodName.substring(3),
 						false);
 				}
+			}
+		}
+	}
+
+	private void _checkVariableNameByMethodCall(
+		DetailAST detailAST, String variableName, String className,
+		String methodName) {
+
+		DetailAST firstChildDetailAST = detailAST.getFirstChild();
+
+		if ((firstChildDetailAST == null) ||
+			(firstChildDetailAST.getType() != TokenTypes.DOT)) {
+
+			return;
+		}
+
+		List<String> names = getNames(firstChildDetailAST, false);
+
+		if ((names.size() != 2) && (names.size() != 3)) {
+			return;
+		}
+
+		String methodCallClassName = names.get(0);
+		String methodCallMethodName = names.get(1);
+
+		if (StringUtil.equals(className, methodCallClassName) &&
+			StringUtil.equals(methodName, methodCallMethodName)) {
+
+			List<DetailAST> parameterExprDetailASTList =
+				getParameterExprDetailASTList(firstChildDetailAST.getParent());
+
+			if (parameterExprDetailASTList.size() <= 2) {
+				return;
+			}
+
+			DetailAST exprDetailAST = parameterExprDetailASTList.get(1);
+
+			firstChildDetailAST = exprDetailAST.getFirstChild();
+
+			if (firstChildDetailAST.getType() != TokenTypes.STRING_LITERAL) {
+				return;
+			}
+
+			String expectedVariableName = _getExpectedVariableName(
+				firstChildDetailAST.getText());
+
+			if (!variableName.matches(
+					"(?i).*" + expectedVariableName + "[0-9]*")) {
+
+				log(
+					detailAST, _MSG_INCORRECT_ENDING_VARIABLE_2, variableName,
+					expectedVariableName);
 			}
 		}
 	}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/VariableNameCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/VariableNameCheck.java
@@ -79,7 +79,7 @@ public class VariableNameCheck extends BaseCheck {
 			_checkExceptionVariableName(detailAST, name, typeName);
 		}
 
-		_checkByMethodCall(detailAST, name);
+		_checkVariableNameByMethodCall(detailAST, name);
 	}
 
 	protected String getExpectedVariableName(String typeName) {
@@ -184,72 +184,6 @@ public class VariableNameCheck extends BaseCheck {
 				log(
 					detailAST, _MSG_INCORRECT_ENDING_VARIABLE_2, variableName,
 					expectedVariableName);
-			}
-		}
-	}
-
-	private void _checkByMethodCall(DetailAST detailAST, String variableName) {
-		DetailAST parentDetailAST = getParentWithTokenType(
-			detailAST, TokenTypes.CLASS_DEF, TokenTypes.CTOR_DEF,
-			TokenTypes.METHOD_DEF);
-
-		if (parentDetailAST == null) {
-			return;
-		}
-
-		List<DetailAST> assignDetailASTList = getAllChildTokens(
-			parentDetailAST, true, TokenTypes.ASSIGN);
-
-		for (DetailAST assignDetailAST : assignDetailASTList) {
-			DetailAST firstChildDetailAST = assignDetailAST.getFirstChild();
-
-			if (firstChildDetailAST == null) {
-				continue;
-			}
-
-			String methodName = StringPool.BLANK;
-
-			if (equals(assignDetailAST.getParent(), detailAST)) {
-				if (firstChildDetailAST.getType() != TokenTypes.EXPR) {
-					continue;
-				}
-
-				firstChildDetailAST = firstChildDetailAST.getFirstChild();
-
-				if (firstChildDetailAST.getType() != TokenTypes.METHOD_CALL) {
-					continue;
-				}
-
-				methodName = getMethodName(firstChildDetailAST);
-
-				if (methodName.equals("stream")) {
-					firstChildDetailAST = firstChildDetailAST.getFirstChild();
-
-					if (firstChildDetailAST.getType() == TokenTypes.DOT) {
-						firstChildDetailAST =
-							firstChildDetailAST.getFirstChild();
-
-						_checkTypo(
-							detailAST, variableName,
-							firstChildDetailAST.getText() + "Stream", false);
-					}
-				}
-			}
-			else if ((firstChildDetailAST.getType() == TokenTypes.IDENT) &&
-					 variableName.equals(firstChildDetailAST.getText())) {
-
-				DetailAST nextSiblingDetailAST =
-					firstChildDetailAST.getNextSibling();
-
-				if (nextSiblingDetailAST.getType() == TokenTypes.METHOD_CALL) {
-					methodName = getMethodName(nextSiblingDetailAST);
-				}
-
-				if (methodName.matches("get[A-Z].*")) {
-					_checkTypo(
-						detailAST, variableName, methodName.substring(3),
-						false);
-				}
 			}
 		}
 	}
@@ -843,6 +777,74 @@ public class VariableNameCheck extends BaseCheck {
 					StringBundler.concat(
 						leadingUnderline, variableName.substring(0, x),
 						typeName, nameTrailingDigits));
+			}
+		}
+	}
+
+	private void _checkVariableNameByMethodCall(
+		DetailAST detailAST, String variableName) {
+
+		DetailAST parentDetailAST = getParentWithTokenType(
+			detailAST, TokenTypes.CLASS_DEF, TokenTypes.CTOR_DEF,
+			TokenTypes.METHOD_DEF);
+
+		if (parentDetailAST == null) {
+			return;
+		}
+
+		List<DetailAST> assignDetailASTList = getAllChildTokens(
+			parentDetailAST, true, TokenTypes.ASSIGN);
+
+		for (DetailAST assignDetailAST : assignDetailASTList) {
+			DetailAST firstChildDetailAST = assignDetailAST.getFirstChild();
+
+			if (firstChildDetailAST == null) {
+				continue;
+			}
+
+			String methodName = StringPool.BLANK;
+
+			if (equals(assignDetailAST.getParent(), detailAST)) {
+				if (firstChildDetailAST.getType() != TokenTypes.EXPR) {
+					continue;
+				}
+
+				firstChildDetailAST = firstChildDetailAST.getFirstChild();
+
+				if (firstChildDetailAST.getType() != TokenTypes.METHOD_CALL) {
+					continue;
+				}
+
+				methodName = getMethodName(firstChildDetailAST);
+
+				if (methodName.equals("stream")) {
+					firstChildDetailAST = firstChildDetailAST.getFirstChild();
+
+					if (firstChildDetailAST.getType() == TokenTypes.DOT) {
+						firstChildDetailAST =
+							firstChildDetailAST.getFirstChild();
+
+						_checkTypo(
+							detailAST, variableName,
+							firstChildDetailAST.getText() + "Stream", false);
+					}
+				}
+			}
+			else if ((firstChildDetailAST.getType() == TokenTypes.IDENT) &&
+					 variableName.equals(firstChildDetailAST.getText())) {
+
+				DetailAST nextSiblingDetailAST =
+					firstChildDetailAST.getNextSibling();
+
+				if (nextSiblingDetailAST.getType() == TokenTypes.METHOD_CALL) {
+					methodName = getMethodName(nextSiblingDetailAST);
+				}
+
+				if (methodName.matches("get[A-Z].*")) {
+					_checkTypo(
+						detailAST, variableName, methodName.substring(3),
+						false);
+				}
 			}
 		}
 	}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/VariableNameCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/VariableNameCheck.java
@@ -79,67 +79,7 @@ public class VariableNameCheck extends BaseCheck {
 			_checkExceptionVariableName(detailAST, name, typeName);
 		}
 
-		DetailAST parentDetailAST = getParentWithTokenType(
-			detailAST, TokenTypes.CLASS_DEF, TokenTypes.CTOR_DEF,
-			TokenTypes.METHOD_DEF);
-
-		if (parentDetailAST == null) {
-			return;
-		}
-
-		List<DetailAST> assignDetailASTList = getAllChildTokens(
-			parentDetailAST, true, TokenTypes.ASSIGN);
-
-		for (DetailAST assignDetailAST : assignDetailASTList) {
-			firstChildDetailAST = assignDetailAST.getFirstChild();
-
-			if (firstChildDetailAST == null) {
-				continue;
-			}
-
-			String methodName = StringPool.BLANK;
-
-			if (equals(assignDetailAST.getParent(), detailAST)) {
-				if (firstChildDetailAST.getType() != TokenTypes.EXPR) {
-					continue;
-				}
-
-				firstChildDetailAST = firstChildDetailAST.getFirstChild();
-
-				if (firstChildDetailAST.getType() == TokenTypes.METHOD_CALL) {
-					methodName = getMethodName(firstChildDetailAST);
-
-					if (methodName.equals("stream")) {
-						firstChildDetailAST =
-							firstChildDetailAST.getFirstChild();
-
-						if (firstChildDetailAST.getType() == TokenTypes.DOT) {
-							firstChildDetailAST =
-								firstChildDetailAST.getFirstChild();
-
-							_checkTypo(
-								detailAST, name,
-								firstChildDetailAST.getText() + "Stream",
-								false);
-						}
-					}
-				}
-			}
-			else if ((firstChildDetailAST.getType() == TokenTypes.IDENT) &&
-					 name.equals(firstChildDetailAST.getText())) {
-
-				DetailAST nextSiblingDetailAST =
-					firstChildDetailAST.getNextSibling();
-
-				if (nextSiblingDetailAST.getType() == TokenTypes.METHOD_CALL) {
-					methodName = getMethodName(nextSiblingDetailAST);
-				}
-			}
-
-			if (methodName.matches("get[A-Z].*")) {
-				_checkTypo(detailAST, name, methodName.substring(3), false);
-			}
-		}
+		_checkByMethodCall(detailAST, name);
 	}
 
 	protected String getExpectedVariableName(String typeName) {
@@ -244,6 +184,71 @@ public class VariableNameCheck extends BaseCheck {
 				log(
 					detailAST, _MSG_INCORRECT_ENDING_VARIABLE_2, variableName,
 					expectedVariableName);
+			}
+		}
+	}
+
+	private void _checkByMethodCall(DetailAST detailAST, String variableName) {
+		DetailAST parentDetailAST = getParentWithTokenType(
+			detailAST, TokenTypes.CLASS_DEF, TokenTypes.CTOR_DEF,
+			TokenTypes.METHOD_DEF);
+
+		if (parentDetailAST == null) {
+			return;
+		}
+
+		List<DetailAST> assignDetailASTList = getAllChildTokens(
+			parentDetailAST, true, TokenTypes.ASSIGN);
+
+		for (DetailAST assignDetailAST : assignDetailASTList) {
+			DetailAST firstChildDetailAST = assignDetailAST.getFirstChild();
+
+			if (firstChildDetailAST == null) {
+				continue;
+			}
+
+			String methodName = StringPool.BLANK;
+
+			if (equals(assignDetailAST.getParent(), detailAST)) {
+				if (firstChildDetailAST.getType() != TokenTypes.EXPR) {
+					continue;
+				}
+
+				firstChildDetailAST = firstChildDetailAST.getFirstChild();
+
+				if (firstChildDetailAST.getType() == TokenTypes.METHOD_CALL) {
+					methodName = getMethodName(firstChildDetailAST);
+
+					if (methodName.equals("stream")) {
+						firstChildDetailAST =
+							firstChildDetailAST.getFirstChild();
+
+						if (firstChildDetailAST.getType() == TokenTypes.DOT) {
+							firstChildDetailAST =
+								firstChildDetailAST.getFirstChild();
+
+							_checkTypo(
+								detailAST, variableName,
+								firstChildDetailAST.getText() + "Stream",
+								false);
+						}
+					}
+				}
+			}
+			else if ((firstChildDetailAST.getType() == TokenTypes.IDENT) &&
+					 variableName.equals(firstChildDetailAST.getText())) {
+
+				DetailAST nextSiblingDetailAST =
+					firstChildDetailAST.getNextSibling();
+
+				if (nextSiblingDetailAST.getType() == TokenTypes.METHOD_CALL) {
+					methodName = getMethodName(nextSiblingDetailAST);
+				}
+			}
+
+			if (methodName.matches("get[A-Z].*")) {
+				_checkTypo(
+					detailAST, variableName, methodName.substring(3), false);
 			}
 		}
 	}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/VariableNameCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/VariableNameCheck.java
@@ -810,34 +810,34 @@ public class VariableNameCheck extends BaseCheck {
 		String methodCallClassName = names.get(0);
 		String methodCallMethodName = names.get(1);
 
-		if (StringUtil.equals(className, methodCallClassName) &&
-			StringUtil.equals(methodName, methodCallMethodName)) {
+		if (!StringUtil.equals(className, methodCallClassName) ||
+			!StringUtil.equals(methodName, methodCallMethodName)) {
 
-			List<DetailAST> parameterExprDetailASTList =
-				getParameterExprDetailASTList(firstChildDetailAST.getParent());
+			return;
+		}
 
-			if (parameterExprDetailASTList.size() <= 2) {
-				return;
-			}
+		List<DetailAST> parameterExprDetailASTList =
+			getParameterExprDetailASTList(firstChildDetailAST.getParent());
 
-			DetailAST exprDetailAST = parameterExprDetailASTList.get(1);
+		if (parameterExprDetailASTList.size() <= 2) {
+			return;
+		}
 
-			firstChildDetailAST = exprDetailAST.getFirstChild();
+		DetailAST exprDetailAST = parameterExprDetailASTList.get(1);
 
-			if (firstChildDetailAST.getType() != TokenTypes.STRING_LITERAL) {
-				return;
-			}
+		firstChildDetailAST = exprDetailAST.getFirstChild();
 
-			String expectedVariableName = _getExpectedVariableName(
-				firstChildDetailAST.getText());
+		if (firstChildDetailAST.getType() != TokenTypes.STRING_LITERAL) {
+			return;
+		}
 
-			if (!variableName.matches(
-					"(?i).*" + expectedVariableName + "[0-9]*")) {
+		String expectedVariableName = _getExpectedVariableName(
+			firstChildDetailAST.getText());
 
-				log(
-					detailAST, _MSG_INCORRECT_ENDING_VARIABLE_2, variableName,
-					expectedVariableName);
-			}
+		if (!variableName.matches("(?i).*" + expectedVariableName + "[0-9]*")) {
+			log(
+				detailAST, _MSG_INCORRECT_ENDING_VARIABLE_2, variableName,
+				expectedVariableName);
 		}
 	}
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/VariableNameCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/VariableNameCheck.java
@@ -747,7 +747,7 @@ public class VariableNameCheck extends BaseCheck {
 
 				_checkVariableNameByMethodCall(
 					firstChildDetailAST, variableName, "ReflectionTestUtil",
-					"getAndSetFieldValue");
+					"getAndSetFieldValue", detailAST);
 
 				methodName = getMethodName(firstChildDetailAST);
 
@@ -776,7 +776,7 @@ public class VariableNameCheck extends BaseCheck {
 
 				_checkVariableNameByMethodCall(
 					nextSiblingDetailAST, variableName, "ReflectionTestUtil",
-					"getAndSetFieldValue");
+					"getAndSetFieldValue", firstChildDetailAST);
 
 				methodName = getMethodName(nextSiblingDetailAST);
 
@@ -790,10 +790,10 @@ public class VariableNameCheck extends BaseCheck {
 	}
 
 	private void _checkVariableNameByMethodCall(
-		DetailAST detailAST, String variableName, String className,
-		String methodName) {
+		DetailAST methodCallDetailAST, String variableName, String className,
+		String methodName, DetailAST detailAST) {
 
-		DetailAST firstChildDetailAST = detailAST.getFirstChild();
+		DetailAST firstChildDetailAST = methodCallDetailAST.getFirstChild();
 
 		if ((firstChildDetailAST == null) ||
 			(firstChildDetailAST.getType() != TokenTypes.DOT)) {

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/VariableNameCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/VariableNameCheck.java
@@ -722,6 +722,8 @@ public class VariableNameCheck extends BaseCheck {
 			return;
 		}
 
+		String absolutePath = getAbsolutePath();
+
 		List<DetailAST> assignDetailASTList = getAllChildTokens(
 			parentDetailAST, true, TokenTypes.ASSIGN);
 
@@ -745,9 +747,11 @@ public class VariableNameCheck extends BaseCheck {
 					continue;
 				}
 
-				_checkVariableNameByMethodCall(
-					firstChildDetailAST, variableName, "ReflectionTestUtil",
-					"getAndSetFieldValue", detailAST);
+				if (absolutePath.contains("/test/")) {
+					_checkVariableNameByMethodCall(
+						firstChildDetailAST, variableName, "ReflectionTestUtil",
+						"getAndSetFieldValue", detailAST);
+				}
 
 				methodName = getMethodName(firstChildDetailAST);
 
@@ -774,9 +778,12 @@ public class VariableNameCheck extends BaseCheck {
 					continue;
 				}
 
-				_checkVariableNameByMethodCall(
-					nextSiblingDetailAST, variableName, "ReflectionTestUtil",
-					"getAndSetFieldValue", firstChildDetailAST);
+				if (absolutePath.contains("/test/")) {
+					_checkVariableNameByMethodCall(
+						nextSiblingDetailAST, variableName,
+						"ReflectionTestUtil", "getAndSetFieldValue",
+						firstChildDetailAST);
+				}
 
 				methodName = getMethodName(nextSiblingDetailAST);
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/VariableNameCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/VariableNameCheck.java
@@ -216,22 +216,22 @@ public class VariableNameCheck extends BaseCheck {
 
 				firstChildDetailAST = firstChildDetailAST.getFirstChild();
 
-				if (firstChildDetailAST.getType() == TokenTypes.METHOD_CALL) {
-					methodName = getMethodName(firstChildDetailAST);
+				if (firstChildDetailAST.getType() != TokenTypes.METHOD_CALL) {
+					continue;
+				}
 
-					if (methodName.equals("stream")) {
+				methodName = getMethodName(firstChildDetailAST);
+
+				if (methodName.equals("stream")) {
+					firstChildDetailAST = firstChildDetailAST.getFirstChild();
+
+					if (firstChildDetailAST.getType() == TokenTypes.DOT) {
 						firstChildDetailAST =
 							firstChildDetailAST.getFirstChild();
 
-						if (firstChildDetailAST.getType() == TokenTypes.DOT) {
-							firstChildDetailAST =
-								firstChildDetailAST.getFirstChild();
-
-							_checkTypo(
-								detailAST, variableName,
-								firstChildDetailAST.getText() + "Stream",
-								false);
-						}
+						_checkTypo(
+							detailAST, variableName,
+							firstChildDetailAST.getText() + "Stream", false);
 					}
 				}
 			}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/VariableNameCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/VariableNameCheck.java
@@ -722,8 +722,6 @@ public class VariableNameCheck extends BaseCheck {
 			return;
 		}
 
-		String absolutePath = getAbsolutePath();
-
 		List<DetailAST> assignDetailASTList = getAllChildTokens(
 			parentDetailAST, true, TokenTypes.ASSIGN);
 
@@ -733,8 +731,6 @@ public class VariableNameCheck extends BaseCheck {
 			if (firstChildDetailAST == null) {
 				continue;
 			}
-
-			String methodName = StringPool.BLANK;
 
 			if (equals(assignDetailAST.getParent(), detailAST)) {
 				if (firstChildDetailAST.getType() != TokenTypes.EXPR) {
@@ -747,13 +743,15 @@ public class VariableNameCheck extends BaseCheck {
 					continue;
 				}
 
+				String absolutePath = getAbsolutePath();
+
 				if (absolutePath.contains("/test/")) {
 					_checkVariableNameByMethodCall(
 						firstChildDetailAST, variableName, "ReflectionTestUtil",
 						"getAndSetFieldValue", detailAST);
 				}
 
-				methodName = getMethodName(firstChildDetailAST);
+				String methodName = getMethodName(firstChildDetailAST);
 
 				if (methodName.equals("stream")) {
 					firstChildDetailAST = firstChildDetailAST.getFirstChild();
@@ -778,6 +776,8 @@ public class VariableNameCheck extends BaseCheck {
 					continue;
 				}
 
+				String absolutePath = getAbsolutePath();
+
 				if (absolutePath.contains("/test/")) {
 					_checkVariableNameByMethodCall(
 						nextSiblingDetailAST, variableName,
@@ -785,7 +785,7 @@ public class VariableNameCheck extends BaseCheck {
 						firstChildDetailAST);
 				}
 
-				methodName = getMethodName(nextSiblingDetailAST);
+				String methodName = getMethodName(nextSiblingDetailAST);
 
 				if (methodName.matches("get[A-Z].*")) {
 					_checkTypo(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/VariableNameCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/VariableNameCheck.java
@@ -843,8 +843,8 @@ public class VariableNameCheck extends BaseCheck {
 
 		if (!variableName.matches("(?i).*" + expectedVariableName + "[0-9]*")) {
 			log(
-				detailAST, _MSG_INCORRECT_ENDING_VARIABLE_2, variableName,
-				expectedVariableName);
+				detailAST, _MSG_INCORRECT_ENDING_VARIABLE_2,
+				className + "." + methodName, expectedVariableName);
 		}
 	}
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/VariableNameCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/VariableNameCheck.java
@@ -51,6 +51,8 @@ public class VariableNameCheck extends BaseCheck {
 
 		if (detailAST.getType() == TokenTypes.VARIABLE_DEF) {
 			_checkClassNameVariable(detailAST, name);
+			_checkByMethod(
+				detailAST, name, "ReflectionTestUtil", "getAndSetFieldValue");
 			_checkTypo(detailAST, name);
 		}
 
@@ -177,6 +179,74 @@ public class VariableNameCheck extends BaseCheck {
 	}
 
 	protected static final String MSG_RENAME_VARIABLE = "variable.rename";
+
+	private void _checkByMethod(
+		DetailAST detailAST, String variableName, String className,
+		String methodName) {
+
+		DetailAST assignDetailAST = detailAST.findFirstToken(TokenTypes.ASSIGN);
+
+		if (assignDetailAST == null) {
+			return;
+		}
+
+		DetailAST firstChildDetailAST = assignDetailAST.getFirstChild();
+
+		if (firstChildDetailAST.getType() != TokenTypes.EXPR) {
+			return;
+		}
+
+		firstChildDetailAST = firstChildDetailAST.getFirstChild();
+
+		if (firstChildDetailAST.getType() != TokenTypes.METHOD_CALL) {
+			return;
+		}
+
+		firstChildDetailAST = firstChildDetailAST.getFirstChild();
+
+		if (firstChildDetailAST.getType() != TokenTypes.DOT) {
+			return;
+		}
+
+		List<String> names = getNames(firstChildDetailAST, false);
+
+		if ((names.size() != 2) && (names.size() != 3)) {
+			return;
+		}
+
+		String methodCallClassName = names.get(0);
+		String methodCallMethodName = names.get(1);
+
+		if (StringUtil.equals(className, methodCallClassName) &&
+			StringUtil.equals(methodName, methodCallMethodName)) {
+
+			List<DetailAST> parameterExprDetailASTList =
+				getParameterExprDetailASTList(firstChildDetailAST.getParent());
+
+			if (parameterExprDetailASTList.size() <= 2) {
+				return;
+			}
+
+			DetailAST exprDetailAST = parameterExprDetailASTList.get(1);
+
+			firstChildDetailAST = exprDetailAST.getFirstChild();
+
+			if (firstChildDetailAST.getType() != TokenTypes.STRING_LITERAL) {
+				return;
+			}
+
+			String expectedVariableName = _getExpectedVariableName(
+				firstChildDetailAST.getText());
+
+			if (!variableName.matches(
+					"(?i).*" + expectedVariableName + "[0-9]*")) {
+
+				log(
+					detailAST, _MSG_INCORRECT_ENDING_VARIABLE_2, variableName,
+					expectedVariableName);
+			}
+		}
+	}
 
 	private void _checkClassNameVariable(
 		DetailAST detailAST, String variableName) {
@@ -575,7 +645,7 @@ public class VariableNameCheck extends BaseCheck {
 						"(?i).*" + expectedVariableName + "[0-9]*")) {
 
 					log(
-						detailAST, _MSG_INCORRECT_ENDING_VARIABLE, typeName,
+						detailAST, _MSG_INCORRECT_ENDING_VARIABLE_1, typeName,
 						expectedVariableName);
 
 					return;
@@ -614,7 +684,7 @@ public class VariableNameCheck extends BaseCheck {
 
 		if (typeName.endsWith("Impl")) {
 			log(
-				detailAST, _MSG_INCORRECT_ENDING_VARIABLE, typeName,
+				detailAST, _MSG_INCORRECT_ENDING_VARIABLE_1, typeName,
 				expectedVariableName);
 
 			return;
@@ -626,7 +696,7 @@ public class VariableNameCheck extends BaseCheck {
 		for (String enforceTypeName : enforceTypeNames) {
 			if (typeName.matches(enforceTypeName)) {
 				log(
-					detailAST, _MSG_INCORRECT_ENDING_VARIABLE, typeName,
+					detailAST, _MSG_INCORRECT_ENDING_VARIABLE_1, typeName,
 					expectedVariableName);
 
 				return;
@@ -899,6 +969,10 @@ public class VariableNameCheck extends BaseCheck {
 		}
 
 		if (s.matches("[A-Z0-9_]+")) {
+			if (s.startsWith("_")) {
+				s = s.substring(1);
+			}
+
 			return TextFormatter.format(
 				StringUtil.replace(StringUtil.toLowerCase(s), '_', '-'),
 				TextFormatter.M);
@@ -984,8 +1058,11 @@ public class VariableNameCheck extends BaseCheck {
 	private static final String _MSG_INCORRECT_COUNT_VARIABLE =
 		"variable.incorrect.count";
 
-	private static final String _MSG_INCORRECT_ENDING_VARIABLE =
-		"variable.incorrect.ending";
+	private static final String _MSG_INCORRECT_ENDING_VARIABLE_1 =
+		"variable.incorrect.ending.1";
+
+	private static final String _MSG_INCORRECT_ENDING_VARIABLE_2 =
+		"variable.incorrect.ending.2";
 
 	private static final String _MSG_INCORRECT_NAME_FOR_STATEMENT =
 		"variable.name.incorrect.for.statement";

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/VariableNameCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/VariableNameCheck.java
@@ -810,15 +810,9 @@ public class VariableNameCheck extends BaseCheck {
 
 		List<String> names = getNames(firstChildDetailAST, false);
 
-		if (names.size() != 2) {
-			return;
-		}
-
-		String methodCallClassName = names.get(0);
-		String methodCallMethodName = names.get(1);
-
-		if (!StringUtil.equals(className, methodCallClassName) ||
-			!StringUtil.equals(methodName, methodCallMethodName)) {
+		if ((names.size() != 2) ||
+			!StringUtil.equals(className, names.get(0)) ||
+			!StringUtil.equals(methodName, names.get(1))) {
 
 			return;
 		}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/VariableNameCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/VariableNameCheck.java
@@ -756,14 +756,15 @@ public class VariableNameCheck extends BaseCheck {
 				if (methodName.equals("stream")) {
 					firstChildDetailAST = firstChildDetailAST.getFirstChild();
 
-					if (firstChildDetailAST.getType() == TokenTypes.DOT) {
-						firstChildDetailAST =
-							firstChildDetailAST.getFirstChild();
-
-						_checkTypo(
-							detailAST, variableName,
-							firstChildDetailAST.getText() + "Stream", false);
+					if (firstChildDetailAST.getType() != TokenTypes.DOT) {
+						continue;
 					}
+
+					firstChildDetailAST = firstChildDetailAST.getFirstChild();
+
+					_checkTypo(
+						detailAST, variableName,
+						firstChildDetailAST.getText() + "Stream", false);
 				}
 			}
 			else if ((firstChildDetailAST.getType() == TokenTypes.IDENT) &&
@@ -787,11 +788,12 @@ public class VariableNameCheck extends BaseCheck {
 
 				String methodName = getMethodName(nextSiblingDetailAST);
 
-				if (methodName.matches("get[A-Z].*")) {
-					_checkTypo(
-						detailAST, variableName, methodName.substring(3),
-						false);
+				if (!methodName.matches("get[A-Z].*")) {
+					continue;
 				}
+
+				_checkTypo(
+					detailAST, variableName, methodName.substring(3), false);
 			}
 		}
 	}
@@ -1034,15 +1036,13 @@ public class VariableNameCheck extends BaseCheck {
 			return true;
 		}
 
-		if (childDetailAST.getType() == TokenTypes.IDENT) {
-			String name = childDetailAST.getText();
-
-			if (name.equals("Boolean")) {
-				return true;
-			}
+		if (childDetailAST.getType() != TokenTypes.IDENT) {
+			return false;
 		}
 
-		return false;
+		String name = childDetailAST.getText();
+
+		return name.equals("Boolean");
 	}
 
 	private static final String _ALLOWED_VARIABLE_NAMES_KEY =

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/VariableNameCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/VariableNameCheck.java
@@ -803,7 +803,7 @@ public class VariableNameCheck extends BaseCheck {
 
 		List<String> names = getNames(firstChildDetailAST, false);
 
-		if ((names.size() != 2) && (names.size() != 3)) {
+		if (names.size() != 2) {
 			return;
 		}
 
@@ -819,7 +819,7 @@ public class VariableNameCheck extends BaseCheck {
 		List<DetailAST> parameterExprDetailASTList =
 			getParameterExprDetailASTList(firstChildDetailAST.getParent());
 
-		if (parameterExprDetailASTList.size() <= 2) {
+		if (parameterExprDetailASTList.size() < 2) {
 			return;
 		}
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/VariableNameCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/VariableNameCheck.java
@@ -867,14 +867,20 @@ public class VariableNameCheck extends BaseCheck {
 			return null;
 		}
 
-		DetailAST parameterDetailAST = getParameterDetailAST(
+		DetailAST firstParameterExprDetailAST = getFirstParameterExprDetailAST(
 			firstChildDetailAST.getParent());
 
-		if (parameterDetailAST.getType() != TokenTypes.STRING_LITERAL) {
+		if (firstParameterExprDetailAST == null) {
 			return null;
 		}
 
-		String s = parameterDetailAST.getText();
+		firstChildDetailAST = firstParameterExprDetailAST.getFirstChild();
+
+		if (firstChildDetailAST.getType() != TokenTypes.STRING_LITERAL) {
+			return null;
+		}
+
+		String s = firstChildDetailAST.getText();
 
 		s = TextFormatter.format(
 			StringUtil.replace(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/VariableNameCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/VariableNameCheck.java
@@ -244,11 +244,12 @@ public class VariableNameCheck extends BaseCheck {
 				if (nextSiblingDetailAST.getType() == TokenTypes.METHOD_CALL) {
 					methodName = getMethodName(nextSiblingDetailAST);
 				}
-			}
 
-			if (methodName.matches("get[A-Z].*")) {
-				_checkTypo(
-					detailAST, variableName, methodName.substring(3), false);
+				if (methodName.matches("get[A-Z].*")) {
+					_checkTypo(
+						detailAST, variableName, methodName.substring(3),
+						false);
+				}
 			}
 		}
 	}

--- a/modules/util/source-formatter/src/main/resources/checkstyle-jsp.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle-jsp.xml
@@ -435,7 +435,8 @@
 			<property name="description" value="Checks that variable names follow naming conventions." />
 			<property name="enforceTypeNames" value="" />
 			<message key="variable.incorrect.count" value="Rename variable &quot;{0}&quot; to &quot;{1}&quot; (and increment counts for other variables &quot;{0}*&quot;)" />
-			<message key="variable.incorrect.ending" value="Name of variable with type &quot;{0}&quot; should end with &quot;{1}&quot;" />
+			<message key="variable.incorrect.ending.1" value="Name of variable with type &quot;{0}&quot; should end with &quot;{1}&quot;" />
+			<message key="variable.incorrect.ending.2" value="Name of variable assigned by &quot;{0}&quot; should end with &quot;{1}&quot;" />
 			<message key="variable.name.incorrect.for.statement" value="Use format &quot;curVariableName&quot; for variable &quot;{0}&quot;" />
 			<message key="variable.rename" value="Rename variable &quot;{0}&quot; to &quot;{1}&quot;" />
 			<message key="variable.typo" value="Typo in variable &quot;{0}&quot;, expected variable name &quot;{1}&quot;" />

--- a/modules/util/source-formatter/src/main/resources/checkstyle.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle.xml
@@ -1023,7 +1023,7 @@
 			<property name="enforceTypeNames" value="" />
 			<message key="variable.incorrect.count" value="Rename variable &quot;{0}&quot; to &quot;{1}&quot; (and increment counts for other variables &quot;{0}*&quot;)" />
 			<message key="variable.incorrect.ending.1" value="Name of variable with type &quot;{0}&quot; should end with &quot;{1}&quot;" />
-			<message key="variable.incorrect.ending.2" value="Name of variable &quot;{0}&quot; should end with &quot;{1}&quot;" />
+			<message key="variable.incorrect.ending.2" value="Name of variable assigned by &quot;{0}&quot; should end with &quot;{1}&quot;" />
 			<message key="variable.name.incorrect.for.statement" value="Use format &quot;curVariableName&quot; for variable &quot;{0}&quot;" />
 			<message key="variable.rename" value="Rename variable &quot;{0}&quot; to &quot;{1}&quot;" />
 			<message key="variable.typo" value="Typo in variable &quot;{0}&quot;, expected variable name &quot;{1}&quot;" />

--- a/modules/util/source-formatter/src/main/resources/checkstyle.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle.xml
@@ -1022,7 +1022,8 @@
 			<property name="description" value="Checks that variable names follow naming conventions." />
 			<property name="enforceTypeNames" value="" />
 			<message key="variable.incorrect.count" value="Rename variable &quot;{0}&quot; to &quot;{1}&quot; (and increment counts for other variables &quot;{0}*&quot;)" />
-			<message key="variable.incorrect.ending" value="Name of variable with type &quot;{0}&quot; should end with &quot;{1}&quot;" />
+			<message key="variable.incorrect.ending.1" value="Name of variable with type &quot;{0}&quot; should end with &quot;{1}&quot;" />
+			<message key="variable.incorrect.ending.2" value="Name of variable &quot;{0}&quot; should end with &quot;{1}&quot;" />
 			<message key="variable.name.incorrect.for.statement" value="Use format &quot;curVariableName&quot; for variable &quot;{0}&quot;" />
 			<message key="variable.rename" value="Rename variable &quot;{0}&quot; to &quot;{1}&quot;" />
 			<message key="variable.typo" value="Typo in variable &quot;{0}&quot;, expected variable name &quot;{1}&quot;" />

--- a/portal-impl/test/unit/com/liferay/portal/kernel/internal/service/persistence/TableMapperTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/internal/service/persistence/TableMapperTest.java
@@ -1681,7 +1681,7 @@ public class TableMapperTest {
 
 	@Test
 	public void testTableMapperFactoryCache() {
-		Set<String> cacheMappingTableNames =
+		Set<String> cachelessMappingTableNames =
 			ReflectionTestUtil.getAndSetFieldValue(
 				TableMapperFactory.class, "_cachelessMappingTableNames",
 				new HashSet<String>() {
@@ -1699,7 +1699,7 @@ public class TableMapperTest {
 		finally {
 			ReflectionTestUtil.setFieldValue(
 				TableMapperFactory.class, "_cachelessMappingTableNames",
-				cacheMappingTableNames);
+				cachelessMappingTableNames);
 		}
 	}
 


### PR DESCRIPTION
```
java.lang.Exception: Found 6 formatting issues:
1: Name of variable "value" should end with "sessionCookieDomain": /Users/alan/liferay_code/master/liferay-portal/modules/apps/cookies/cookies-test/src/test/java/com/liferay/cookies/internal/manager/CookiesDomainTest.java 106 (Checkstyle:VariableNameCheck)
2: Name of variable "value" should end with "sessionCookieUseFullHostname": /Users/alan/liferay_code/master/liferay-portal/modules/apps/cookies/cookies-test/src/test/java/com/liferay/cookies/internal/manager/CookiesDomainTest.java 128 (Checkstyle:VariableNameCheck)
3: Name of variable "value" should end with "sessionCookieUseFullHostname": /Users/alan/liferay_code/master/liferay-portal/modules/apps/cookies/cookies-test/src/test/java/com/liferay/cookies/internal/manager/CookiesDomainTest.java 151 (Checkstyle:VariableNameCheck)
4: Name of variable "snapshot" should end with "portletDataHandlerSnapshot": /Users/alan/liferay_code/master/liferay-portal/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/ExportedMissingReferenceExportImportTest.java 304 (Checkstyle:VariableNameCheck)
5: Name of variable "map" should end with "tesseractPresent": /Users/alan/liferay_code/master/liferay-portal/modules/apps/portal/portal-tika-test/src/testIntegration/java/com/liferay/portal/tika/test/TextExtractorTest.java 67 (Checkstyle:VariableNameCheck)
6: Name of variable "cacheMappingTableNames" should end with "cachelessMappingTableNames": /Users/alan/liferay_code/master/liferay-portal/portal-impl/test/unit/com/liferay/portal/kernel/internal/service/persistence/TableMapperTest.java 1684 (Checkstyle:VariableNameCheck)

```