### PR TITLE
LPD-52029 Consistent variable names within one class

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMFormValuesUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMFormValuesUtil.java
@@ -201,12 +201,12 @@ public class DDMFormValuesUtil {
 	}
 
 	private static List<DDMFormFieldValue> _toDDMFormFieldValues(
-		List<ContentField> contentFields, DDMFormField ddmFormField,
+		List<ContentField> contentFieldsList, DDMFormField ddmFormField,
 		DLAppService dlAppService, long groupId,
 		JournalArticleService journalArticleService,
 		LayoutLocalService layoutLocalService, Locale locale) {
 
-		if (ListUtil.isEmpty(contentFields)) {
+		if (ListUtil.isEmpty(contentFieldsList)) {
 			if (ddmFormField.isRequired()) {
 				throw new BadRequestException(
 					"No value is specified for field " +
@@ -221,7 +221,7 @@ public class DDMFormValuesUtil {
 		}
 
 		return TransformUtil.transform(
-			contentFields,
+			contentFieldsList,
 			contentField -> _toDDMFormFieldValue(
 				contentField.getNestedContentFields(), ddmFormField,
 				dlAppService, groupId, journalArticleService,

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMFormValuesUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMFormValuesUtil.java
@@ -75,7 +75,7 @@ public class DDMFormValuesUtil {
 		LayoutLocalService layoutLocalService, Locale locale,
 		List<DDMFormField> rootDDMFormFields) {
 
-		Map<String, List<ContentField>> contentFieldMap = _toContentFieldsMap(
+		Map<String, List<ContentField>> contentFieldsMap = _toContentFieldsMap(
 			contentFields);
 
 		return new DDMFormValues(ddmForm) {
@@ -86,7 +86,7 @@ public class DDMFormValuesUtil {
 					_flattenDDMFormFieldValues(
 						rootDDMFormFields,
 						ddmFormField -> _toDDMFormFieldValues(
-							contentFieldMap.get(
+							contentFieldsMap.get(
 								ddmFormField.getFieldReference()),
 							ddmFormField, dlAppService, groupId,
 							journalArticleService, layoutLocalService,
@@ -181,7 +181,7 @@ public class DDMFormValuesUtil {
 		JournalArticleService journalArticleService,
 		LayoutLocalService layoutLocalService, Locale locale, Value value) {
 
-		Map<String, List<ContentField>> contentFieldMap = _toContentFieldsMap(
+		Map<String, List<ContentField>> contentFieldsMap = _toContentFieldsMap(
 			contentFields);
 
 		return new DDMFormFieldValue() {
@@ -192,7 +192,7 @@ public class DDMFormValuesUtil {
 					_flattenDDMFormFieldValues(
 						ddmFormField.getNestedDDMFormFields(),
 						field -> _toDDMFormFieldValues(
-							contentFieldMap.get(field.getFieldReference()),
+							contentFieldsMap.get(field.getFieldReference()),
 							field, dlAppService, groupId, journalArticleService,
 							layoutLocalService, locale)));
 				setValue(value);


### PR DESCRIPTION
We have
`ContentField[] contentFields`
`List<ContentField> contentFieldsList`
`Map<String, List<ContentField>> contentFieldsMap`
within one class.