### PR TITLE
LPD-54817 New SF rule: REST Builder's compatibility version require a breaking change commit description

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BNDBreakingChangeCommitMessageCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BNDBreakingChangeCommitMessageCheck.java
@@ -11,9 +11,6 @@ import com.liferay.portal.tools.GitUtil;
 import com.liferay.source.formatter.SourceFormatterArgs;
 import com.liferay.source.formatter.processor.SourceProcessor;
 
-import java.util.Iterator;
-import java.util.List;
-
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 
@@ -45,58 +42,12 @@ public class BNDBreakingChangeCommitMessageCheck
 		}
 
 		if (_hasMajorVersionBump(absolutePath, sourceFormatterArgs)) {
-			_checkCommitMessages(fileName, absolutePath, sourceFormatterArgs);
+			checkCommitMessages(
+				fileName, absolutePath, sourceFormatterArgs,
+				"the major version bumps up");
 		}
 
 		return content;
-	}
-
-	private void _checkCommitMessages(
-			String fileName, String absolutePath,
-			SourceFormatterArgs sourceFormatterArgs)
-		throws Exception {
-
-		List<String> commitMessages = GitUtil.getCurrentBranchCommitMessages(
-			sourceFormatterArgs.getBaseDirName(),
-			sourceFormatterArgs.getGitWorkingBranchName());
-
-		Iterator<String> iterator = commitMessages.iterator();
-
-		while (iterator.hasNext()) {
-			String commitMessage = iterator.next();
-
-			String[] parts = commitMessage.split(":", 2);
-
-			if (!parts[1].contains("# breaking")) {
-				iterator.remove();
-			}
-		}
-
-		if (commitMessages.isEmpty()) {
-			addMessage(
-				fileName,
-				"Incorrect commit message: Missing breaking change in commit " +
-					"messages when the major version bumps up");
-
-			return;
-		}
-
-		for (String commitMessage : commitMessages) {
-			String[] parts = commitMessage.split(":", 2);
-
-			if (!parts[1].contains("# breaking")) {
-				continue;
-			}
-
-			String message =
-				"Incorrect commit message in SHA " + parts[0] + ": ";
-
-			checkMissingEmptyLinesAroundHeaders(fileName, parts[1], message);
-
-			checkBreakingChanges(
-				fileName, absolutePath, parts[1].split("\n----"), message,
-				true);
-		}
 	}
 
 	private boolean _hasMajorVersionBump(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BNDBreakingChangeCommitMessageCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BNDBreakingChangeCommitMessageCheck.java
@@ -99,27 +99,12 @@ public class BNDBreakingChangeCommitMessageCheck
 		}
 	}
 
-	private synchronized List<String> _getCurrentBranchFileNames(
-			SourceFormatterArgs sourceFormatterArgs)
-		throws Exception {
-
-		if (_currentBranchFileNames != null) {
-			return _currentBranchFileNames;
-		}
-
-		_currentBranchFileNames = GitUtil.getCurrentBranchFileNames(
-			sourceFormatterArgs.getBaseDirName(),
-			sourceFormatterArgs.getGitWorkingBranchName());
-
-		return _currentBranchFileNames;
-	}
-
 	private boolean _hasMajorVersionBump(
 			String absolutePath, SourceFormatterArgs sourceFormatterArgs)
 		throws Exception {
 
 		for (String currentBranchFileName :
-				_getCurrentBranchFileNames(sourceFormatterArgs)) {
+				getCurrentBranchFileNames(sourceFormatterArgs)) {
 
 			if (!absolutePath.endsWith(currentBranchFileName)) {
 				continue;
@@ -161,7 +146,5 @@ public class BNDBreakingChangeCommitMessageCheck
 
 		return false;
 	}
-
-	private static List<String> _currentBranchFileNames;
 
 }

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BaseBreakingChangesCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BaseBreakingChangesCheck.java
@@ -16,6 +16,7 @@ import com.liferay.source.formatter.check.util.SourceUtil;
 
 import java.io.IOException;
 
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -105,6 +106,54 @@ public abstract class BaseBreakingChangesCheck extends BaseFileCheck {
 
 				return;
 			}
+		}
+	}
+
+	protected void checkCommitMessages(
+			String fileName, String absolutePath,
+			SourceFormatterArgs sourceFormatterArgs, String additionalMessage)
+		throws Exception {
+
+		List<String> commitMessages = GitUtil.getCurrentBranchCommitMessages(
+			sourceFormatterArgs.getBaseDirName(),
+			sourceFormatterArgs.getGitWorkingBranchName());
+
+		Iterator<String> iterator = commitMessages.iterator();
+
+		while (iterator.hasNext()) {
+			String commitMessage = iterator.next();
+
+			String[] parts = commitMessage.split(":", 2);
+
+			if (!parts[1].contains("# breaking")) {
+				iterator.remove();
+			}
+		}
+
+		if (commitMessages.isEmpty()) {
+			addMessage(
+				fileName,
+				"Incorrect commit message: Missing breaking change in commit " +
+					"messages when " + additionalMessage);
+
+			return;
+		}
+
+		for (String commitMessage : commitMessages) {
+			String[] parts = commitMessage.split(":", 2);
+
+			if (!parts[1].contains("# breaking")) {
+				continue;
+			}
+
+			String message =
+				"Incorrect commit message in SHA " + parts[0] + ": ";
+
+			checkMissingEmptyLinesAroundHeaders(fileName, parts[1], message);
+
+			checkBreakingChanges(
+				fileName, absolutePath, parts[1].split("\n----"), message,
+				true);
 		}
 	}
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BaseBreakingChangesCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BaseBreakingChangesCheck.java
@@ -10,9 +10,13 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.tools.GitUtil;
+import com.liferay.source.formatter.SourceFormatterArgs;
 import com.liferay.source.formatter.check.util.SourceUtil;
 
 import java.io.IOException;
+
+import java.util.List;
 
 /**
  * @author Alan Huang
@@ -154,6 +158,21 @@ public abstract class BaseBreakingChangesCheck extends BaseFileCheck {
 		}
 	}
 
+	protected synchronized List<String> getCurrentBranchFileNames(
+			SourceFormatterArgs sourceFormatterArgs)
+		throws Exception {
+
+		if (_currentBranchFileNames != null) {
+			return _currentBranchFileNames;
+		}
+
+		_currentBranchFileNames = GitUtil.getCurrentBranchFileNames(
+			sourceFormatterArgs.getBaseDirName(),
+			sourceFormatterArgs.getGitWorkingBranchName());
+
+		return _currentBranchFileNames;
+	}
+
 	private void _checkMissingExplanation(
 		String fileName, String breakingChange, String message,
 		int... headerPositions) {
@@ -190,5 +209,7 @@ public abstract class BaseBreakingChangesCheck extends BaseFileCheck {
 
 	private static final String _LIFERAY_PORTAL_MASTER_URL =
 		"https://github.com/liferay/liferay-portal/blob/master/";
+
+	private static List<String> _currentBranchFileNames;
 
 }

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/YMLRESTConfigFileBreakingChangeCommitMessageCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/YMLRESTConfigFileBreakingChangeCommitMessageCheck.java
@@ -14,7 +14,7 @@ import com.liferay.source.formatter.processor.SourceProcessor;
 /**
  * @author Alan Huang
  */
-public class YMLRestConfigFileBreakingChangeCommitMessageCheck
+public class YMLRESTConfigFileBreakingChangeCommitMessageCheck
 	extends BaseBreakingChangesCheck {
 
 	@Override

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/YMLRestConfigFileBreakingChangeCommitMessageCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/YMLRestConfigFileBreakingChangeCommitMessageCheck.java
@@ -11,9 +11,6 @@ import com.liferay.portal.tools.GitUtil;
 import com.liferay.source.formatter.SourceFormatterArgs;
 import com.liferay.source.formatter.processor.SourceProcessor;
 
-import java.util.Iterator;
-import java.util.List;
-
 /**
  * @author Alan Huang
  */
@@ -35,58 +32,12 @@ public class YMLRestConfigFileBreakingChangeCommitMessageCheck
 			sourceProcessor.getSourceFormatterArgs();
 
 		if (_hasCompatibilityVersionBump(absolutePath, sourceFormatterArgs)) {
-			_checkCommitMessages(fileName, absolutePath, sourceFormatterArgs);
+			checkCommitMessages(
+				fileName, absolutePath, sourceFormatterArgs,
+				"compatibilityVersion bumps up");
 		}
 
 		return content;
-	}
-
-	private void _checkCommitMessages(
-			String fileName, String absolutePath,
-			SourceFormatterArgs sourceFormatterArgs)
-		throws Exception {
-
-		List<String> commitMessages = GitUtil.getCurrentBranchCommitMessages(
-			sourceFormatterArgs.getBaseDirName(),
-			sourceFormatterArgs.getGitWorkingBranchName());
-
-		Iterator<String> iterator = commitMessages.iterator();
-
-		while (iterator.hasNext()) {
-			String commitMessage = iterator.next();
-
-			String[] parts = commitMessage.split(":", 2);
-
-			if (!parts[1].contains("# breaking")) {
-				iterator.remove();
-			}
-		}
-
-		if (commitMessages.isEmpty()) {
-			addMessage(
-				fileName,
-				"Incorrect commit message: Missing breaking change in commit " +
-					"messages when compatibilityVersion bumps up");
-
-			return;
-		}
-
-		for (String commitMessage : commitMessages) {
-			String[] parts = commitMessage.split(":", 2);
-
-			if (!parts[1].contains("# breaking")) {
-				continue;
-			}
-
-			String message =
-				"Incorrect commit message in SHA " + parts[0] + ": ";
-
-			checkMissingEmptyLinesAroundHeaders(fileName, parts[1], message);
-
-			checkBreakingChanges(
-				fileName, absolutePath, parts[1].split("\n----"), message,
-				true);
-		}
 	}
 
 	private boolean _hasCompatibilityVersionBump(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/YMLRestConfigFileBreakingChangeCommitMessageCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/YMLRestConfigFileBreakingChangeCommitMessageCheck.java
@@ -1,0 +1,153 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.check;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.tools.GitUtil;
+import com.liferay.source.formatter.SourceFormatterArgs;
+import com.liferay.source.formatter.processor.SourceProcessor;
+
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * @author Alan Huang
+ */
+public class YMLRestConfigFileBreakingChangeCommitMessageCheck
+	extends BaseBreakingChangesCheck {
+
+	@Override
+	protected String doProcess(
+			String fileName, String absolutePath, String content)
+		throws Exception {
+
+		if (!fileName.endsWith("/rest-config.yaml")) {
+			return content;
+		}
+
+		SourceProcessor sourceProcessor = getSourceProcessor();
+
+		SourceFormatterArgs sourceFormatterArgs =
+			sourceProcessor.getSourceFormatterArgs();
+
+		if (_hasCompatibilityVersionBump(absolutePath, sourceFormatterArgs)) {
+			_checkCommitMessages(fileName, absolutePath, sourceFormatterArgs);
+		}
+
+		return content;
+	}
+
+	private void _checkCommitMessages(
+			String fileName, String absolutePath,
+			SourceFormatterArgs sourceFormatterArgs)
+		throws Exception {
+
+		List<String> commitMessages = GitUtil.getCurrentBranchCommitMessages(
+			sourceFormatterArgs.getBaseDirName(),
+			sourceFormatterArgs.getGitWorkingBranchName());
+
+		Iterator<String> iterator = commitMessages.iterator();
+
+		while (iterator.hasNext()) {
+			String commitMessage = iterator.next();
+
+			String[] parts = commitMessage.split(":", 2);
+
+			if (!parts[1].contains("# breaking")) {
+				iterator.remove();
+			}
+		}
+
+		if (commitMessages.isEmpty()) {
+			addMessage(
+				fileName,
+				"Incorrect commit message: Missing breaking change in commit " +
+					"messages when compatibilityVersion bumps up");
+
+			return;
+		}
+
+		for (String commitMessage : commitMessages) {
+			String[] parts = commitMessage.split(":", 2);
+
+			if (!parts[1].contains("# breaking")) {
+				continue;
+			}
+
+			String message =
+				"Incorrect commit message in SHA " + parts[0] + ": ";
+
+			checkMissingEmptyLinesAroundHeaders(fileName, parts[1], message);
+
+			checkBreakingChanges(
+				fileName, absolutePath, parts[1].split("\n----"), message,
+				true);
+		}
+	}
+
+	private synchronized List<String> _getCurrentBranchFileNames(
+			SourceFormatterArgs sourceFormatterArgs)
+		throws Exception {
+
+		if (_currentBranchFileNames != null) {
+			return _currentBranchFileNames;
+		}
+
+		_currentBranchFileNames = GitUtil.getCurrentBranchFileNames(
+			sourceFormatterArgs.getBaseDirName(),
+			sourceFormatterArgs.getGitWorkingBranchName());
+
+		return _currentBranchFileNames;
+	}
+
+	private boolean _hasCompatibilityVersionBump(
+			String absolutePath, SourceFormatterArgs sourceFormatterArgs)
+		throws Exception {
+
+		for (String currentBranchFileName :
+				_getCurrentBranchFileNames(sourceFormatterArgs)) {
+
+			if (!absolutePath.endsWith(currentBranchFileName)) {
+				continue;
+			}
+
+			String newCompatibilityVersion = null;
+			String oldCompatibilityVersion = null;
+
+			String[] lines = StringUtil.splitLines(
+				GitUtil.getCurrentBranchFileDiff(
+					sourceFormatterArgs.getBaseDirName(),
+					sourceFormatterArgs.getGitWorkingBranchName(),
+					absolutePath));
+
+			for (String line : lines) {
+				if (!line.contains("compatibilityVersion:")) {
+					continue;
+				}
+
+				int pos = line.indexOf(":");
+
+				String version = StringUtil.trim(line.substring(pos + 1));
+
+				if (line.startsWith(StringPool.PLUS)) {
+					newCompatibilityVersion = version;
+				}
+				else if (line.startsWith(StringPool.DASH)) {
+					oldCompatibilityVersion = version;
+				}
+			}
+
+			return !StringUtil.equals(
+				newCompatibilityVersion, oldCompatibilityVersion);
+		}
+
+		return false;
+	}
+
+	private static List<String> _currentBranchFileNames;
+
+}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/YMLRestConfigFileBreakingChangeCommitMessageCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/YMLRestConfigFileBreakingChangeCommitMessageCheck.java
@@ -89,27 +89,12 @@ public class YMLRestConfigFileBreakingChangeCommitMessageCheck
 		}
 	}
 
-	private synchronized List<String> _getCurrentBranchFileNames(
-			SourceFormatterArgs sourceFormatterArgs)
-		throws Exception {
-
-		if (_currentBranchFileNames != null) {
-			return _currentBranchFileNames;
-		}
-
-		_currentBranchFileNames = GitUtil.getCurrentBranchFileNames(
-			sourceFormatterArgs.getBaseDirName(),
-			sourceFormatterArgs.getGitWorkingBranchName());
-
-		return _currentBranchFileNames;
-	}
-
 	private boolean _hasCompatibilityVersionBump(
 			String absolutePath, SourceFormatterArgs sourceFormatterArgs)
 		throws Exception {
 
 		for (String currentBranchFileName :
-				_getCurrentBranchFileNames(sourceFormatterArgs)) {
+				getCurrentBranchFileNames(sourceFormatterArgs)) {
 
 			if (!absolutePath.endsWith(currentBranchFileName)) {
 				continue;
@@ -147,7 +132,5 @@ public class YMLRestConfigFileBreakingChangeCommitMessageCheck
 
 		return false;
 	}
-
-	private static List<String> _currentBranchFileNames;
 
 }

--- a/modules/util/source-formatter/src/main/resources/documentation/all_checks.md
+++ b/modules/util/source-formatter/src/main/resources/documentation/all_checks.md
@@ -620,5 +620,6 @@ YMLDefinitionOrderCheck | [Styling](styling_checks.md#styling-checks) | .tpl, .y
 YMLEmptyLinesCheck | [Styling](styling_checks.md#styling-checks) | .tpl, .yaml, or .yml | Finds missing and unnecessary empty lines. |
 YMLIndentationCheck | [Styling](styling_checks.md#styling-checks) | .tpl, .yaml, or .yml | Finds incorrect indentation in YAML files. |
 YMLLongLinesCheck | [Styling](styling_checks.md#styling-checks) | .tpl, .yaml, or .yml | Finds lines that are longer than the specified maximum line length. |
+YMLRESTConfigFileBreakingChangeCommitMessageCheck | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | .tpl, .yaml, or .yml | Checks that commit message should contain the schematized breaking changes. |
 YMLStylingCheck | [Styling](styling_checks.md#styling-checks) | .tpl, .yaml, or .yml | Applies rules to enforce consistency in code style. |
 YMLWhitespaceCheck | [Styling](styling_checks.md#styling-checks) | .tpl, .yaml, or .yml | Finds missing and unnecessary whitespace in `.yml` files. |

--- a/modules/util/source-formatter/src/main/resources/documentation/bug_prevention_checks.md
+++ b/modules/util/source-formatter/src/main/resources/documentation/bug_prevention_checks.md
@@ -238,3 +238,4 @@ XMLSourcechecksFileCheck | .action, .function, .jelly, .jrxml, .macro, .pom, .pr
 XMLSuppressionsFileCheck | .action, .function, .jelly, .jrxml, .macro, .pom, .project, .properties, .svg, .testcase, .toggle, .tpl, .wsdl, .xml, or .xsd | Performs several checks on `source-formatter-suppressions.xml` file. |
 XMLTagAttributesCheck | .action, .function, .html, .jelly, .jrxml, .macro, .path, .pom, .project, .properties, .svg, .testcase, .toggle, .tpl, .wsdl, .xml, or .xsd | Performs several checks on tag attributes. |
 XMLWebFileCheck | .action, .function, .jelly, .jrxml, .macro, .pom, .project, .properties, .svg, .testcase, .toggle, .tpl, .wsdl, .xml, or .xsd | Performs several checks on `web.xml` file. |
+YMLRESTConfigFileBreakingChangeCommitMessageCheck | .tpl, .yaml, or .yml | Checks that commit message should contain the schematized breaking changes. |

--- a/modules/util/source-formatter/src/main/resources/documentation/yml_source_processor_checks.md
+++ b/modules/util/source-formatter/src/main/resources/documentation/yml_source_processor_checks.md
@@ -6,5 +6,6 @@ YMLDefinitionOrderCheck | [Styling](styling_checks.md#styling-checks) | Sorts de
 YMLEmptyLinesCheck | [Styling](styling_checks.md#styling-checks) | Finds missing and unnecessary empty lines. |
 YMLIndentationCheck | [Styling](styling_checks.md#styling-checks) | Finds incorrect indentation in YAML files. |
 YMLLongLinesCheck | [Styling](styling_checks.md#styling-checks) | Finds lines that are longer than the specified maximum line length. |
+YMLRESTConfigFileBreakingChangeCommitMessageCheck | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | Checks that commit message should contain the schematized breaking changes. |
 YMLStylingCheck | [Styling](styling_checks.md#styling-checks) | Applies rules to enforce consistency in code style. |
 YMLWhitespaceCheck | [Styling](styling_checks.md#styling-checks) | Finds missing and unnecessary whitespace in `.yml` files. |

--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -2206,7 +2206,7 @@
 			<description name="Finds lines that are longer than the specified maximum line length." />
 			<property name="maxLineLength" value="120" />
 		</check>
-		<check name="YMLRestConfigFileBreakingChangeCommitMessageCheck">
+		<check name="YMLRESTConfigFileBreakingChangeCommitMessageCheck">
 			<category name="Bug Prevention" />
 			<description name="Checks that commit message should contain the schematized breaking changes." />
 		</check>

--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -2206,6 +2206,10 @@
 			<description name="Finds lines that are longer than the specified maximum line length." />
 			<property name="maxLineLength" value="120" />
 		</check>
+		<check name="YMLRestConfigFileBreakingChangeCommitMessageCheck">
+			<category name="Bug Prevention" />
+			<description name="Checks that commit message should contain the schematized breaking changes." />
+		</check>
 		<check name="YMLStylingCheck">
 			<category name="Styling" />
 			<description name="Applies rules to enforce consistency in code style." />

--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -2209,6 +2209,7 @@
 		<check name="YMLRESTConfigFileBreakingChangeCommitMessageCheck">
 			<category name="Bug Prevention" />
 			<description name="Checks that commit message should contain the schematized breaking changes." />
+			<property name="enabled" value="false" />
 		</check>
 		<check name="YMLStylingCheck">
 			<category name="Styling" />

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -1662,3 +1662,5 @@
     source.check.XMLSpringExtenderServiceCheck.enabled=true
 
     source.check.XMLWorkflowDefinitionFileNameCheck.enabled=true
+
+    source.check.YMLRESTConfigFileBreakingChangeCommitMessageCheck.enabled=true


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-54817

REST builder in order to add new functionalities that could break the classes generated for clients that use a older portal version (since the latest REST Builder code is executed in every branch) has a property within the rest-config.yaml files found in REST Builder modules called "**compatibilityVersion**"

With each version of this property, comes a new functionality that wont work unless the portal version is updated.

This kind of changes could be considered as breaking change since with each one of this the APIs could get broken if not updated properly.

This task purpose is making SF check if a commit that contains a change in the compatibility version contains a description similar to the one found in breaking change commits (see the example below):

---------------

LPD-49868 Update compatibilityVersion to 9 in order to apply the changes
```
# breaking

## What /modules/apps/headless/headless-admin-site/headless-admin-site-api/src/main/java/com/liferay/headless/admin/site/resource/v1_0/DisplayPageTemplateFolderResource.java

REST Builder compatibility version has been updated due to the introduction of new functionalities

## Why

xxxx

----
```