### PR TITLE
LPD-30966 Fix broken integration tests by restricting sort cases

### DIFF
--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/BaseSourceProcessorTestCase.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/BaseSourceProcessorTestCase.java
@@ -141,11 +141,17 @@ public abstract class BaseSourceProcessorTestCase {
 					modifiedFileNames);
 			}
 
-			_checkExpectedMessages(
-				expectedMessages, newFile,
-				ListUtil.sort(
+			List<String> checkCategoryNames =
+				sourceFormatterArgs.getCheckCategoryNames();
+
+			if (checkCategoryNames.contains("Upgrade")) {
+				sourceFormatterMessages = ListUtil.sort(
 					sourceFormatterMessages,
-					Comparator.comparing(SourceFormatterMessage::getMessage)),
+					Comparator.comparing(SourceFormatterMessage::getMessage));
+			}
+
+			_checkExpectedMessages(
+				expectedMessages, newFile, sourceFormatterMessages,
 				sourceProcessorTestParameters);
 		}
 		else {


### PR DESCRIPTION
Hi @ling-alan-huang, sorry about the issue caused when I refactored the Base class. I’ve done some additional testing, and the sort is still necessary in the Base class for theese cases.

Regardless of the order sent by `UpgradeCatchAllCheck`, the `sourceFormatterMessages` arrive at this point in a different order, so I can’t handle ordering inside the check itself.

For `UpgradeCatchAllCheck` cases, the `ExpectedMessages` are generated automatically from the JSON, so the outcome doesn’t depend on the specific file or case sequence. To prevent test failures caused only by ordering differences, this sort step in the Base class is required.