### PR TITLE
LPD-81938 Apply SF rules to try-with-resources statements?

### DIFF
--- a/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/upgrade/v1_2_0/CookiesPreferenceHandlingConfigurationUpgradeProcess.java
+++ b/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/upgrade/v1_2_0/CookiesPreferenceHandlingConfigurationUpgradeProcess.java
@@ -35,12 +35,14 @@ public class CookiesPreferenceHandlingConfigurationUpgradeProcess
 		}
 
 		try (Statement statement = connection.createStatement();
+
 			ResultSet resultSet = statement.executeQuery(
 				StringBundler.concat(
 					"select * from Configuration_ where configurationId LIKE ",
 					"'%",
 					CookiesPreferenceHandlingConfiguration.class.getName(),
 					"%'"));
+
 			PreparedStatement preparedStatement =
 				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
 					connection,


### PR DESCRIPTION
Can I apply SF rules to try-with-resources statements:
```
1: There should be an empty line between assigning and using variable "statement": /Users/alan/liferay_code/master/liferay-portal/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/upgrade/v1_2_0/CookiesPreferenceHandlingConfigurationUpgradeProcess.java 38 (Checkstyle:MissingEmptyLineCheck)
2: There should be an empty line before line "44", as we finished referencing variable "statement": /Users/alan/liferay_code/master/liferay-portal/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/upgrade/v1_2_0/CookiesPreferenceHandlingConfigurationUpgradeProcess.java 44 (Checkstyle:MissingEmptyLineCheck)

```