### PR TITLE
LPD-98666 Add JavaRedundantContainsCheck

### DIFF
--- a/modules/apps/object/object-service/src/test/java/com/liferay/object/internal/related/models/ObjectEntryMtoMObjectRelatedModelsPredicateProviderImplTest.java
+++ b/modules/apps/object/object-service/src/test/java/com/liferay/object/internal/related/models/ObjectEntryMtoMObjectRelatedModelsPredicateProviderImplTest.java
@@ -119,8 +119,7 @@ public class ObjectEntryMtoMObjectRelatedModelsPredicateProviderImplTest
 
 		String predicateString = _getPredicateString(
 			new Long[] {RandomTestUtil.randomLong()}, objectDefinition,
-			_mockObjectFieldLocalService(
-				objectDefinitionId2),
+			_mockObjectFieldLocalService(objectDefinitionId2),
 			mockObjectRelationship(
 				objectDefinitionId1, objectDefinitionId2,
 				RandomTestUtil.randomString()),

--- a/modules/apps/static/portal/portal-encryptor/src/main/java/com/liferay/portal/encryptor/EncryptorImpl.java
+++ b/modules/apps/static/portal/portal-encryptor/src/main/java/com/liferay/portal/encryptor/EncryptorImpl.java
@@ -281,9 +281,9 @@ public class EncryptorImpl implements Encryptor {
 
 	private static final Log _log = LogFactoryUtil.getLog(EncryptorImpl.class);
 
-	private final Map<String, Cipher> _decryptCiphers =
-		new ConcurrentHashMap<>(1, 1F, 1);
-	private final Map<String, Cipher> _encryptCiphers =
-		new ConcurrentHashMap<>(1, 1F, 1);
+	private final Map<String, Cipher> _decryptCiphers = new ConcurrentHashMap<>(
+		1, 1F, 1);
+	private final Map<String, Cipher> _encryptCiphers = new ConcurrentHashMap<>(
+		1, 1F, 1);
 
 }

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BatchTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BatchTestEntityResourceImpl.java
@@ -286,11 +286,7 @@ public class BatchTestEntityResourceImpl
 	}
 
 	private BatchTestEntity _fetchBatchTestEntity(long id) {
-		if (_batchTestEntities.containsKey(id)) {
-			return _batchTestEntities.get(id);
-		}
-
-		return null;
+		return _batchTestEntities.get(id);
 	}
 
 	private BatchTestEntity _fetchBatchTestEntity(

--- a/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BatchTestEntityResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder-test-impl/src/main/java/com/liferay/portal/tools/rest/builder/test/internal/resource/v1_0/BatchTestEntityResourceImpl.java
@@ -358,9 +358,10 @@ public class BatchTestEntityResourceImpl
 					() -> NestedFieldsSupplier.supply(
 						"relatedCompanyTestEntity",
 						nestedField -> {
-							if (!_relationships.containsKey(
-									originalBatchTestEntity.getId())) {
+							Long companyTestEntityId = _relationships.get(
+								originalBatchTestEntity.getId());
 
+							if (companyTestEntityId == null) {
 								return null;
 							}
 
@@ -373,9 +374,7 @@ public class BatchTestEntityResourceImpl
 								).build();
 
 							return companyTestEntityResource.
-								getCompanyTestEntity(
-									_relationships.get(
-										originalBatchTestEntity.getId()));
+								getCompanyTestEntity(companyTestEntityId);
 						}));
 			}
 		};

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/util/OpenAPIParserUtil.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/util/OpenAPIParserUtil.java
@@ -593,8 +593,10 @@ public class OpenAPIParserUtil {
 							String key = getReferenceName(
 								parameter.getReference());
 
-							if (parameterMap.containsKey(key)) {
-								parameters.set(i, parameterMap.get(key));
+							Parameter curParameter = parameterMap.get(key);
+
+							if (curParameter != null) {
+								parameters.set(i, curParameter);
 							}
 						}
 					}

--- a/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
+++ b/modules/util/portal-tools-sample-sql-builder/src/main/java/com/liferay/portal/tools/sample/sql/builder/DataFactory.java
@@ -7333,14 +7333,10 @@ public class DataFactory {
 
 			String key = jsonObject.getString("layoutColumnId");
 
-			if (portletNames.containsKey(key)) {
-				portletNames.put(
-					key,
-					portletNames.get(key) + StringPool.COMMA + portletName);
-			}
-			else {
-				portletNames.put(key, portletName);
-			}
+			portletNames.merge(
+				key, portletName,
+				(currentPortletName, newPortletName) ->
+					currentPortletName + StringPool.COMMA + newPortletName);
 		}
 
 		return ArrayUtil.toStringArray(portletNames.values());

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/PythonImportsFormatter.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/PythonImportsFormatter.java
@@ -120,8 +120,10 @@ public class PythonImportsFormatter extends BaseImportsFormatter {
 
 			String packageName = matcher.group(2);
 
-			if (packageImportsMap.containsKey(packageName)) {
-				importNamesList.addAll(packageImportsMap.get(packageName));
+			List<String> curImportNames = packageImportsMap.get(packageName);
+
+			if (curImportNames != null) {
+				importNamesList.addAll(curImportNames);
 			}
 
 			packageImportsMap.put(packageName, importNamesList);

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BaseSourceCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BaseSourceCheck.java
@@ -65,11 +65,8 @@ public abstract class BaseSourceCheck implements SourceCheck {
 	public Set<SourceFormatterMessage> getSourceFormatterMessages(
 		String fileName) {
 
-		if (_sourceFormatterMessagesMap.containsKey(fileName)) {
-			return _sourceFormatterMessagesMap.get(fileName);
-		}
-
-		return Collections.emptySet();
+		return _sourceFormatterMessagesMap.getOrDefault(
+			fileName, Collections.emptySet());
 	}
 
 	@Override

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/GradleDependencyArtifactsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/GradleDependencyArtifactsCheck.java
@@ -251,10 +251,12 @@ public class GradleDependencyArtifactsCheck extends BaseFileCheck {
 				Map<String, String> projectNamesMap = _getProjectNamesMap(
 					absolutePath);
 
-				if (projectNamesMap.containsKey(name)) {
+				String projectName = projectNamesMap.get(name);
+
+				if (projectName != null) {
 					return StringUtil.replace(
 						content, dependency,
-						"project(\"" + projectNamesMap.get(name) + "\")");
+						"project(\"" + projectName + "\")");
 				}
 
 				addMessage(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JSPTagAttributesCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JSPTagAttributesCheck.java
@@ -414,8 +414,11 @@ public class JSPTagAttributesCheck extends BaseTagAttributesCheck {
 		throws Exception {
 
 		if (_tagSetMethodsMap != null) {
-			if (_tagSetMethodsMap.containsKey(tagName)) {
-				return _tagSetMethodsMap.get(tagName);
+			Map<String, String> tagSetMethodsMap = _tagSetMethodsMap.get(
+				tagName);
+
+			if (tagSetMethodsMap != null) {
+				return tagSetMethodsMap;
 			}
 
 			return _tagSetMethodsMap.get("liferay-" + tagName);
@@ -527,11 +530,14 @@ public class JSPTagAttributesCheck extends BaseTagAttributesCheck {
 			String tagFileName, String utilTaglibSrcDirName)
 		throws Exception {
 
-		if (_classSetMethodsMap.containsKey(tagFileName)) {
-			return _classSetMethodsMap.get(tagFileName);
+		Map<String, String> setMethodsMap = _classSetMethodsMap.get(
+			tagFileName);
+
+		if (setMethodsMap != null) {
+			return setMethodsMap;
 		}
 
-		Map<String, String> setMethodsMap = new HashMap<>();
+		setMethodsMap = new HashMap<>();
 
 		File tagFile = new File(tagFileName);
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaDuplicateVariableCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaDuplicateVariableCheck.java
@@ -122,11 +122,14 @@ public class JavaDuplicateVariableCheck extends BaseJavaTermCheck {
 			String absolutePath, String fullyQualifiedClassName)
 		throws IOException {
 
-		if (_javaVariablesMap.containsKey(fullyQualifiedClassName)) {
-			return _javaVariablesMap.get(fullyQualifiedClassName);
+		Map<String, List<JavaVariable>> javaVariablesMap =
+			_javaVariablesMap.get(fullyQualifiedClassName);
+
+		if (javaVariablesMap != null) {
+			return javaVariablesMap;
 		}
 
-		Map<String, List<JavaVariable>> javaVariablesMap = new HashMap<>();
+		javaVariablesMap = new HashMap<>();
 
 		File file = JavaSourceUtil.getJavaFile(
 			fullyQualifiedClassName, _getRootDirName(absolutePath),

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaRedundantContainsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaRedundantContainsCheck.java
@@ -1,0 +1,379 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.check;
+
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.source.formatter.parser.JavaTerm;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class JavaRedundantContainsCheck extends BaseJavaTermCheck {
+
+	@Override
+	public boolean isLiferaySourceCheck() {
+		return true;
+	}
+
+	@Override
+	protected String doProcess(
+		String fileName, String absolutePath, JavaTerm javaTerm,
+		String fileContent) {
+
+		String content = javaTerm.getContent();
+
+		if (_isAllowedFileName(
+				absolutePath,
+				getAttributeValues(_ALLOWED_FILE_NAMES_KEY, absolutePath))) {
+
+			return content;
+		}
+
+		String blankedContent = _blankComments(content);
+
+		Matcher matcher = _containsPattern.matcher(blankedContent);
+
+		while (matcher.find()) {
+			boolean negated = false;
+
+			if (matcher.group(1) != null) {
+				negated = true;
+			}
+
+			String receiver = matcher.group(2);
+
+			boolean map = false;
+
+			if (matcher.group(3) != null) {
+				map = true;
+			}
+
+			int[] keyPositions = _getBalancedPositions(
+				blankedContent, matcher.end());
+
+			if (keyPositions == null) {
+				continue;
+			}
+
+			String key = blankedContent.substring(
+				keyPositions[0], keyPositions[1]);
+
+			if (_hasTopLevelComma(key)) {
+				continue;
+			}
+
+			int i = keyPositions[1] + 1;
+
+			if ((i >= blankedContent.length()) ||
+				(blankedContent.charAt(i) != ')')) {
+
+				continue;
+			}
+
+			i++;
+
+			while ((i < blankedContent.length()) &&
+				   Character.isWhitespace(blankedContent.charAt(i))) {
+
+				i++;
+			}
+
+			if ((i >= blankedContent.length()) ||
+				(blankedContent.charAt(i) != '{')) {
+
+				continue;
+			}
+
+			String firstStatement = _getFirstStatement(blankedContent, i + 1);
+
+			if (firstStatement == null) {
+				continue;
+			}
+
+			String operation = null;
+			String suggestion = null;
+
+			if (map && negated) {
+				operation = "put";
+				suggestion = "a single \"putIfAbsent\" or \"computeIfAbsent\"";
+			}
+			else if (map) {
+				if (_hasOperation(
+						firstStatement, receiver, "get", key, false)) {
+
+					operation = "get";
+					suggestion = "a single \"get\" with a null check";
+				}
+				else if (_hasOperation(
+							firstStatement, receiver, "remove", key, false)) {
+
+					operation = "remove";
+					suggestion = "a single \"remove\" with a null check";
+				}
+			}
+			else if (negated) {
+				if (!_isSetTypedReceiver(fileContent, receiver)) {
+					continue;
+				}
+
+				operation = "add";
+				suggestion = "the boolean result of a single \"add\"";
+			}
+			else {
+				operation = "remove";
+				suggestion = "the boolean result of a single \"remove\"";
+			}
+
+			if (operation == null) {
+				continue;
+			}
+
+			if ((map && !negated) ||
+				_hasOperation(
+					firstStatement, receiver, operation, key,
+					operation.equals("put"))) {
+
+				addMessage(
+					fileName,
+					StringBundler.concat(
+						"Combine the \"contains", map ? "Key" : "",
+						"\" check on \"", receiver, "\" and the following \"",
+						operation, "\" into ", suggestion),
+					javaTerm.getLineNumber(matcher.start()));
+			}
+		}
+
+		return content;
+	}
+
+	@Override
+	protected String[] getCheckableJavaTermNames() {
+		return new String[] {JAVA_METHOD};
+	}
+
+	private String _blankComments(String content) {
+		char[] chars = content.toCharArray();
+
+		int i = 0;
+
+		while (i < chars.length) {
+			char c = chars[i];
+
+			if ((c == CharPool.QUOTE) || (c == CharPool.APOSTROPHE)) {
+				i++;
+
+				while ((i < chars.length) && (chars[i] != c)) {
+					if (chars[i] == CharPool.BACK_SLASH) {
+						i++;
+					}
+
+					i++;
+				}
+
+				i++;
+			}
+			else if ((c == CharPool.SLASH) && ((i + 1) < chars.length) &&
+					 (chars[i + 1] == CharPool.SLASH)) {
+
+				while ((i < chars.length) && (chars[i] != CharPool.NEW_LINE)) {
+					chars[i] = CharPool.SPACE;
+
+					i++;
+				}
+			}
+			else if ((c == CharPool.SLASH) && ((i + 1) < chars.length) &&
+					 (chars[i + 1] == CharPool.STAR)) {
+
+				while (i < chars.length) {
+					if ((chars[i] == CharPool.STAR) &&
+						((i + 1) < chars.length) &&
+						(chars[i + 1] == CharPool.SLASH)) {
+
+						chars[i] = CharPool.SPACE;
+						chars[i + 1] = CharPool.SPACE;
+
+						i += 2;
+
+						break;
+					}
+
+					if (chars[i] != CharPool.NEW_LINE) {
+						chars[i] = CharPool.SPACE;
+					}
+
+					i++;
+				}
+			}
+			else {
+				i++;
+			}
+		}
+
+		return new String(chars);
+	}
+
+	private int[] _getBalancedPositions(String content, int openParenPos) {
+		int level = 1;
+
+		for (int i = openParenPos; i < content.length(); i++) {
+			char c = content.charAt(i);
+
+			if (c == '(') {
+				level++;
+			}
+			else if (c == ')') {
+				level--;
+
+				if (level == 0) {
+					return new int[] {openParenPos, i};
+				}
+			}
+		}
+
+		return null;
+	}
+
+	private String _getFirstStatement(String content, int blockStartPos) {
+		int level = 0;
+
+		for (int i = blockStartPos; i < content.length(); i++) {
+			char c = content.charAt(i);
+
+			if ((c == '(') || (c == '{')) {
+				level++;
+			}
+			else if ((c == ')') || (c == '}')) {
+				if ((c == '}') && (level == 0)) {
+					return content.substring(blockStartPos, i);
+				}
+
+				level--;
+			}
+			else if ((c == ';') && (level == 0)) {
+				return content.substring(blockStartPos, i + 1);
+			}
+		}
+
+		return null;
+	}
+
+	private boolean _hasOperation(
+		String statement, String receiver, String operation, String key,
+		boolean keyIsFirstArgument) {
+
+		Pattern pattern = Pattern.compile(
+			StringBundler.concat(
+				Pattern.quote(receiver), "\\s*\\.\\s*", operation, "\\s*\\("));
+
+		Matcher matcher = pattern.matcher(statement);
+
+		while (matcher.find()) {
+			int[] argsPositions = _getBalancedPositions(
+				statement, matcher.end());
+
+			if (argsPositions == null) {
+				return false;
+			}
+
+			String args = statement.substring(
+				argsPositions[0], argsPositions[1]);
+
+			if (keyIsFirstArgument) {
+				int level = 0;
+
+				for (int i = 0; i < args.length(); i++) {
+					char c = args.charAt(i);
+
+					if ((c == '(') || (c == '<') || (c == '[')) {
+						level++;
+					}
+					else if ((c == ')') || (c == '>') || (c == ']')) {
+						level--;
+					}
+					else if ((c == ',') && (level == 0)) {
+						args = args.substring(0, i);
+
+						break;
+					}
+				}
+			}
+
+			if (Objects.equals(_normalize(args), _normalize(key))) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private boolean _hasTopLevelComma(String s) {
+		int level = 0;
+
+		for (int i = 0; i < s.length(); i++) {
+			char c = s.charAt(i);
+
+			if ((c == '(') || (c == '<') || (c == '[')) {
+				level++;
+			}
+			else if ((c == ')') || (c == '>') || (c == ']')) {
+				level--;
+			}
+			else if ((c == ',') && (level == 0)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private boolean _isAllowedFileName(
+		String absolutePath, List<String> allowedFileNames) {
+
+		for (String allowedFileName : allowedFileNames) {
+			if (absolutePath.endsWith(allowedFileName)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private boolean _isSetTypedReceiver(String fileContent, String receiver) {
+		Pattern pattern = Pattern.compile(
+			StringBundler.concat(
+				"\\b\\w*Set\\s*(<[^<>]*(<[^<>]*>)?[^<>]*>)?\\s+",
+				Pattern.quote(receiver), "\\b"));
+
+		Matcher matcher = pattern.matcher(fileContent);
+
+		if (matcher.find()) {
+			return true;
+		}
+
+		pattern = Pattern.compile(
+			Pattern.quote(receiver) + "\\s*=\\s*new\\s+\\w*Set\\s*[<(]");
+
+		matcher = pattern.matcher(fileContent);
+
+		return matcher.find();
+	}
+
+	private String _normalize(String s) {
+		return s.replaceAll("\\s+", "");
+	}
+
+	private static final String _ALLOWED_FILE_NAMES_KEY = "allowedFileNames";
+
+	private static final Pattern _containsPattern = Pattern.compile(
+		"if \\((!)?(\\w+)\\.contains(Key)?\\(");
+
+}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/XMLServiceFinderNameCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/XMLServiceFinderNameCheck.java
@@ -120,13 +120,14 @@ public class XMLServiceFinderNameCheck extends BaseFileCheck {
 		if (finderColumns.size() == 1) {
 			Map<String, String> finderColumn = finderColumns.get(0);
 
-			if (!finderColumn.containsKey("name")) {
+			String name = finderColumn.get("name");
+
+			if (name == null) {
 				return;
 			}
 
 			String expectedFinderName = _checkCaps(
-				TextFormatter.format(
-					finderColumn.get("name"), TextFormatter.G));
+				TextFormatter.format(name, TextFormatter.G));
 
 			String comparator = finderColumn.get("comparator");
 
@@ -154,11 +155,11 @@ public class XMLServiceFinderNameCheck extends BaseFileCheck {
 
 		outerLoop:
 		for (Map<String, String> finderColumn : finderColumns) {
-			if (!finderColumn.containsKey("name")) {
+			String finderColumnName = finderColumn.get("name");
+
+			if (finderColumnName == null) {
 				continue;
 			}
-
-			String finderColumnName = finderColumn.get("name");
 
 			finderColumnName = StringUtil.upperCase(
 				finderColumnName.substring(0, 1));

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/XMLServiceFinderNameCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/XMLServiceFinderNameCheck.java
@@ -128,10 +128,11 @@ public class XMLServiceFinderNameCheck extends BaseFileCheck {
 				TextFormatter.format(
 					finderColumn.get("name"), TextFormatter.G));
 
-			if (finderColumn.containsKey("comparator")) {
+			String comparator = finderColumn.get("comparator");
+
+			if (comparator != null) {
 				expectedFinderName =
-					_comparatorNamesMap.get(finderColumn.get("comparator")) +
-						expectedFinderName;
+					_comparatorNamesMap.get(comparator) + expectedFinderName;
 			}
 
 			if (!finderName.startsWith(expectedFinderName)) {
@@ -164,9 +165,10 @@ public class XMLServiceFinderNameCheck extends BaseFileCheck {
 
 			String expectedFinderName = StringPool.BLANK;
 
-			if (finderColumn.containsKey("comparator")) {
-				expectedFinderName += _comparatorNamesMap.get(
-					finderColumn.get("comparator"));
+			String comparator = finderColumn.get("comparator");
+
+			if (comparator != null) {
+				expectedFinderName += _comparatorNamesMap.get(comparator);
 			}
 
 			expectedFinderName = expectedFinderName + finderColumnName;

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/YMLDefinitionOrderCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/YMLDefinitionOrderCheck.java
@@ -470,11 +470,7 @@ public class YMLDefinitionOrderCheck extends BaseFileCheck {
 		}
 
 		private int _getParameterWeight(String definitionKey) {
-			if (_parametersWeightMap.containsKey(definitionKey)) {
-				return _parametersWeightMap.get(definitionKey);
-			}
-
-			return -1;
+			return _parametersWeightMap.getOrDefault(definitionKey, -1);
 		}
 
 		private int _sortMounts(String mountPath1, String mountPath2) {

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/BaseCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/BaseCheck.java
@@ -1594,11 +1594,13 @@ public abstract class BaseCheck extends AbstractCheck {
 	}
 
 	private List<String> _getJSPImportNames(String directoryName) {
-		if (_jspImportNamesMap.containsKey(directoryName)) {
-			return _jspImportNamesMap.get(directoryName);
+		List<String> importNames = _jspImportNamesMap.get(directoryName);
+
+		if (importNames != null) {
+			return importNames;
 		}
 
-		List<String> importNames = new ArrayList<>();
+		importNames = new ArrayList<>();
 
 		String fileName = directoryName + "/init.jsp";
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/RESTDTOSetCallCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/RESTDTOSetCallCheck.java
@@ -231,8 +231,10 @@ public class RESTDTOSetCallCheck extends BaseCheck {
 	private JavaClass _getDTOJavaClass(
 		String absolutePath, String fullyQualifiedTypeName) {
 
-		if (_dtoJavaClasses.containsKey(fullyQualifiedTypeName)) {
-			return _dtoJavaClasses.get(fullyQualifiedTypeName);
+		JavaClass dtoJavaClass = _dtoJavaClasses.get(fullyQualifiedTypeName);
+
+		if (dtoJavaClass != null) {
+			return dtoJavaClass;
 		}
 
 		File javaFile = JavaSourceUtil.getJavaFile(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/DebugUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/DebugUtil.java
@@ -184,13 +184,15 @@ public class DebugUtil {
 	}
 
 	private static void _printProcessingTimeInformation(CheckType checkType) {
-		if (!_checkNamesMap.containsKey(checkType)) {
+		List<String> checkNames = _checkNamesMap.get(checkType);
+
+		if (checkNames == null) {
 			return;
 		}
 
 		final Map<String, Double> checkTypeProcessingTimeMap = new HashMap<>();
 
-		for (String checkName : _checkNamesMap.get(checkType)) {
+		for (String checkName : checkNames) {
 			Double processingTime = _processingTimeMap.get(checkName);
 
 			if (processingTime != null) {

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/DebugUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/DebugUtil.java
@@ -49,11 +49,8 @@ public class DebugUtil {
 	public static synchronized void increaseProcessingTime(
 		String checkName, long processingTime) {
 
-		double checkTotalProcessingTime = 0.0;
-
-		if (_processingTimeMap.containsKey(checkName)) {
-			checkTotalProcessingTime = _processingTimeMap.get(checkName);
-		}
+		double checkTotalProcessingTime = _processingTimeMap.getOrDefault(
+			checkName, 0.0);
 
 		checkTotalProcessingTime +=
 			(double)processingTime / Math.max(1, _concurrentTasksCount.get());
@@ -194,9 +191,10 @@ public class DebugUtil {
 		final Map<String, Double> checkTypeProcessingTimeMap = new HashMap<>();
 
 		for (String checkName : _checkNamesMap.get(checkType)) {
-			if (_processingTimeMap.containsKey(checkName)) {
-				checkTypeProcessingTimeMap.put(
-					checkName, _processingTimeMap.get(checkName));
+			Double processingTime = _processingTimeMap.get(checkName);
+
+			if (processingTime != null) {
+				checkTypeProcessingTimeMap.put(checkName, processingTime);
 			}
 		}
 

--- a/modules/util/source-formatter/src/main/resources/documentation/all_checks.md
+++ b/modules/util/source-formatter/src/main/resources/documentation/all_checks.md
@@ -303,6 +303,7 @@ JavaNewProblemInstantiationParametersCheck | [Bug Prevention](bug_prevention_che
 [JavaProcessCallableCheck](check/java_process_callable_check.md#javaprocesscallablecheck) | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | .java | Checks that a class implementing `ProcessCallable` assigns a `serialVersionUID`. |
 JavaProviderTypeAnnotationCheck | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | .java | Performs several checks on classes with `@ProviderType` annotation. |
 JavaRedundantConstructorCheck | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | .java | Finds unnecessary empty constructor. |
+[JavaRedundantContainsCheck](check/java_redundant_contains_check.md#javaredundantcontainscheck) | [Performance](performance_checks.md#performance-checks) | .java | Finds a `contains` or `containsKey` check that is immediately followed by a `get`, `remove`, `put`, or `add` on the same key or element, which should be combined into the single operation that already reports presence through its return value. |
 JavaReferenceAnnotationsCheck | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | .java | Performs several checks on classes with `@Reference` annotations. |
 JavaReleaseInfoCheck | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | .java | Validates information in `ReleaseInfo.java`. |
 JavaReturnStatementCheck | [Styling](styling_checks.md#styling-checks) | .java | Finds unnecessary `else` statement (when `if` and `else` statement both end with `return` statement). |

--- a/modules/util/source-formatter/src/main/resources/documentation/check/java_redundant_contains_check.md
+++ b/modules/util/source-formatter/src/main/resources/documentation/check/java_redundant_contains_check.md
@@ -1,0 +1,46 @@
+## JavaRedundantContainsCheck
+
+Do not guard a map or collection operation with a `contains` or `containsKey`
+check on the same key or element. The operation already reports presence
+through its return value, so the guard costs a second hash lookup.
+
+Combine the two calls into one:
+
+```
+if (map.containsKey(key)) {
+	return map.get(key);
+}
+```
+
+becomes
+
+```
+Value value = map.get(key);
+
+if (value != null) {
+	return value;
+}
+```
+
+Likewise, `if (map.containsKey(key)) { map.remove(key); ... }` becomes a single
+`remove` with a null check, `if (!map.containsKey(key)) { map.put(key, value); }`
+becomes `putIfAbsent` or `computeIfAbsent`, and `if (!set.contains(element)) {
+set.add(element); ... }` and `if (set.contains(element)) { set.remove(element);
+... }` use the boolean result of a single `add` or `remove`.
+
+The merged map forms assume the map does not store null values, which a
+`containsKey` guard distinguishes from absence. When a map legitimately holds
+null values, keep the guard and whitelist the file.
+
+The check only looks at single argument `contains` and `containsKey` calls,
+which are the instance methods on a map or collection. Static helpers that take
+the container as an extra argument, such as `ArrayUtil.contains(array, value)`
+followed by `ArrayUtil.remove(array, value)`, are not flagged: the array
+`remove` builds a new array without reporting presence, so the `contains` guard
+is what avoids the allocation and keeps the branch's side effects conditional.
+
+The `add` form is only flagged when the receiver's declaration resolves to a
+`Set` type. `List.add` and unbounded `Queue.add` always return true, so on
+those types the `contains` guard is the deduplication itself and cannot be
+folded into the `add`. The `remove` forms apply to lists as well, since
+`List.remove(Object)` does report presence.

--- a/modules/util/source-formatter/src/main/resources/documentation/java_source_processor_checks.md
+++ b/modules/util/source-formatter/src/main/resources/documentation/java_source_processor_checks.md
@@ -151,6 +151,7 @@ JavaNewProblemInstantiationParametersCheck | [Bug Prevention](bug_prevention_che
 [JavaProcessCallableCheck](check/java_process_callable_check.md#javaprocesscallablecheck) | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | Checks that a class implementing `ProcessCallable` assigns a `serialVersionUID`. |
 JavaProviderTypeAnnotationCheck | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | Performs several checks on classes with `@ProviderType` annotation. |
 JavaRedundantConstructorCheck | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | Finds unnecessary empty constructor. |
+[JavaRedundantContainsCheck](check/java_redundant_contains_check.md#javaredundantcontainscheck) | [Performance](performance_checks.md#performance-checks) | Finds a `contains` or `containsKey` check that is immediately followed by a `get`, `remove`, `put`, or `add` on the same key or element, which should be combined into the single operation that already reports presence through its return value. |
 JavaReferenceAnnotationsCheck | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | Performs several checks on classes with `@Reference` annotations. |
 JavaReleaseInfoCheck | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | Validates information in `ReleaseInfo.java`. |
 JavaReturnStatementCheck | [Styling](styling_checks.md#styling-checks) | Finds unnecessary `else` statement (when `if` and `else` statement both end with `return` statement). |

--- a/modules/util/source-formatter/src/main/resources/documentation/performance_checks.md
+++ b/modules/util/source-formatter/src/main/resources/documentation/performance_checks.md
@@ -16,6 +16,7 @@ JSPUnusedTermsCheck | .jsp, .jspf, .jspx, .tag, .tpl, or .vm | Finds taglibs, va
 JavaCollapseImportsCheck | .java | Collapses imports that use wildcard. |
 JavaHibernateSQLCheck | .java | Finds calls to `com.liferay.portal.kernel.dao.orm.Session.createSQLQuery` (use `Session.createSynchronizedSQLQuery` instead). |
 [JavaMultiPlusConcatCheck](check/java_multi_plus_concat_check.md#javamultiplusconcatcheck) | .java | Checks that we do not concatenate more than 3 String objects. |
+[JavaRedundantContainsCheck](check/java_redundant_contains_check.md#javaredundantcontainscheck) | .java | Finds a `contains` or `containsKey` check that is immediately followed by a `get`, `remove`, `put`, or `add` on the same key or element, which should be combined into the single operation that already reports presence through its return value. |
 [JavaServiceTrackerFactoryCheck](check/java_service_tracker_factory_check.md#javaservicetrackerfactorycheck) | .java | Checks that there are no calls to deprecated method `ServiceTrackerFactory.open(java.lang.Class)`. |
 JavaSessionCheck | .java | Finds unnecessary calls to `Session.flush()` (calls that are followed by `Session.clear()`). |
 [JavaStringBundlerConcatCheck](check/java_string_bundler_concat_check.md#javastringbundlerconcatcheck) | .java | Finds calls to `StringBundler.concat` with less than 3 parameters. |

--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -889,6 +889,10 @@
 			<category name="Bug Prevention" />
 			<description name="Performs several checks on classes with `@ProviderType` annotation." />
 		</check>
+		<check name="JavaRedundantContainsCheck">
+			<category name="Performance" />
+			<description name="Finds a `contains` or `containsKey` check that is immediately followed by a `get`, `remove`, `put`, or `add` on the same key or element, which should be combined into the single operation that already reports presence through its return value." />
+		</check>
 		<check name="JavaReferenceAnnotationsCheck">
 			<category name="Bug Prevention" />
 			<description name="Performs several checks on classes with `@Reference` annotations." />


### PR DESCRIPTION
[LPD-98666](https://liferay.atlassian.net/browse/LPD-98666)

## What Is Being Fixed

There was no SourceFormatter rule to catch the redundant `containsKey`/`contains` guard immediately followed by `get`/`remove`/`put`/`add` on the same key or element, so the anti-pattern kept spreading across the codebase.

## How It Is Being Fixed

Adds `JavaRedundantContainsCheck`. It flags a first-statement `containsKey`/`contains` on a receiver followed by `get`/`remove`/`put`/`add` on the same key or element, with a Set-typed-receiver filter for the `add` form, a top-level-comma skip, and comment blanking. It is registered in `sourcechecks.xml` with documentation and carries no whitelist.

This PR also fixes the handful of offenders inside the source-formatter and build-tooling modules that the rule flags in its own codebase (`BaseSourceCheck`, `PythonImportsFormatter`, `DebugUtil`, and a few `portal-tools` helpers), and reformats the two files the rebuilt source formatter rewraps.

All product-code offenders are already fixed and sent to Brian (`brianchandotcom`); see the cross-reference comment below. Because this rule has no whitelist, the product-code cleanup must land first so the rule sees zero offenders.
