### PR TITLE
LPD-88886 Add a source formatter check for unmasked credential fields

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaMetaAnnotationsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaMetaAnnotationsCheck.java
@@ -5,6 +5,7 @@
 
 package com.liferay.source.formatter.check;
 
+import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -26,8 +27,14 @@ public class JavaMetaAnnotationsCheck extends JavaAnnotationsCheck {
 			String fileContent)
 		throws Exception {
 
+		JavaClass javaClass = (JavaClass)javaTerm;
+
+		if (javaClass.getParentJavaClass() == null) {
+			_checkMissingPasswordType(fileName, absolutePath, fileContent);
+		}
+
 		return formatAnnotations(
-			fileName, absolutePath, (JavaClass)javaTerm, fileContent);
+			fileName, absolutePath, javaClass, fileContent);
 	}
 
 	@Override
@@ -146,6 +153,46 @@ public class JavaMetaAnnotationsCheck extends JavaAnnotationsCheck {
 			getLineNumber(content, content.indexOf(annotation)));
 	}
 
+	private void _checkMissingPasswordType(
+		String fileName, String absolutePath, String content) {
+
+		if (absolutePath.contains("/archived/") ||
+			absolutePath.contains("/gradleTest/") ||
+			absolutePath.contains("/test/") ||
+			absolutePath.contains("/testIntegration/") ||
+			!content.contains("@Meta.OCD")) {
+
+			return;
+		}
+
+		Matcher matcher = _stringAccessorPattern.matcher(content);
+
+		while (matcher.find()) {
+			String name = matcher.group(1);
+
+			if (!_isSecretName(name)) {
+				continue;
+			}
+
+			int previousSemicolon = content.lastIndexOf(
+				CharPool.SEMICOLON, matcher.start());
+
+			String annotations = content.substring(
+				previousSemicolon + 1, matcher.start());
+
+			if (annotations.contains("Meta.Type.Password")) {
+				continue;
+			}
+
+			addMessage(
+				fileName,
+				StringBundler.concat(
+					"Use \"type = Meta.Type.Password\" in \"@Meta.AD\" for \"",
+					name, "\", which appears to hold a secret"),
+				getLineNumber(content, matcher.start()));
+		}
+	}
+
 	private String _fixOCDId(
 		String fileName, String annotation, String packageName) {
 
@@ -171,10 +218,40 @@ public class JavaMetaAnnotationsCheck extends JavaAnnotationsCheck {
 			annotation, StringPool.PERCENT, StringPool.BLANK, matcher.start());
 	}
 
+	private boolean _isSecretName(String name) {
+		String lowerCaseName = StringUtil.toLowerCase(name);
+
+		for (String excludeKeyword : _EXCLUDED_SECRET_KEYWORDS) {
+			if (lowerCaseName.contains(excludeKeyword)) {
+				return false;
+			}
+		}
+
+		for (String secretKeyword : _SECRET_KEYWORDS) {
+			if (lowerCaseName.contains(secretKeyword)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	private static final String _CHECK_CONFIGURATION_NAME_KEY =
 		"checkConfigurationName";
 
 	private static final String _CHECK_MISSING_NAME_KEY = "checkMissingName";
+
+	private static final String[] _EXCLUDED_SECRET_KEYWORDS = {
+		"algorithm", "field", "keyword", "providerid", "sapentry", "type",
+		"uri", "url"
+	};
+
+	private static final String[] _SECRET_KEYWORDS = {
+		"accesstoken", "apikey", "authkey", "authtoken", "credential",
+		"jsonwebkey", "passphrase", "passwd", "password", "privatekey",
+		"refreshtoken", "secret", "serviceaccountkey", "signaturekey",
+		"subscriptionkey"
+	};
 
 	private static final Pattern _annotationMetaTypePattern = Pattern.compile(
 		"[\\s\\(](name|description) = \"%");
@@ -182,5 +259,7 @@ public class JavaMetaAnnotationsCheck extends JavaAnnotationsCheck {
 		Pattern.compile("\\s(\\w+) = \"([\\w\\.\\-]+?)\"");
 	private static final Pattern _annotationNameValueKeyPattern =
 		Pattern.compile("\\sname = \"([\\w\\.\\-]+?)\"");
+	private static final Pattern _stringAccessorPattern = Pattern.compile(
+		"public\\s+String(?:\\[\\])?\\s+(\\w+)\\s*\\(\\s*\\)\\s*;");
 
 }

--- a/modules/util/source-formatter/src/main/resources/documentation/all_checks.md
+++ b/modules/util/source-formatter/src/main/resources/documentation/all_checks.md
@@ -280,7 +280,7 @@ JavaLogClassNameCheck | [Bug Prevention](bug_prevention_checks.md#bug-prevention
 [JavaLogLevelCheck](check/java_log_level_check.md#javaloglevelcheck) | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | .java | Checks that the correct log messages are printed. |
 JavaLongLinesCheck | [Styling](styling_checks.md#styling-checks) | .java | Finds lines that are longer than the specified maximum line length. |
 JavaMapBuilderGenericsCheck | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | .java | Finds missing or unnecessary generics on `*MapBuilder.put` calls. |
-[JavaMetaAnnotationsCheck](check/java_meta_annotations_check.md#javametaannotationscheck) | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | .java | Checks for correct use of attributes `description` and `name` in annotation `@aQute.bnd.annotation.metatype.Meta`. |
+[JavaMetaAnnotationsCheck](check/java_meta_annotations_check.md#javametaannotationscheck) | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | .java | Checks for correct use of attributes `description`, `name`, and `type` in annotation `@aQute.bnd.annotation.metatype.Meta`, including requiring `type = Meta.Type.Password` on secret-bearing fields. |
 JavaMissingOverrideCheck | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | .java | Finds missing @Override annotations. |
 JavaMissingXMLPublicIdsCheck | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | .java | Finds missing public IDs for check XML files. |
 JavaModifiedServiceMethodCheck | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | .java | Finds missing empty lines before `removedService` or `addingService` calls. |

--- a/modules/util/source-formatter/src/main/resources/documentation/bug_prevention_checks.md
+++ b/modules/util/source-formatter/src/main/resources/documentation/bug_prevention_checks.md
@@ -122,7 +122,7 @@ JavaLiferayFilterCheck | .java | Finds cases of incorrect use of certain method 
 JavaLogClassNameCheck | .java | Checks the name of the class that is passed in `LogFactoryUtil.getLog`. |
 [JavaLogLevelCheck](check/java_log_level_check.md#javaloglevelcheck) | .java | Checks that the correct log messages are printed. |
 JavaMapBuilderGenericsCheck | .java | Finds missing or unnecessary generics on `*MapBuilder.put` calls. |
-[JavaMetaAnnotationsCheck](check/java_meta_annotations_check.md#javametaannotationscheck) | .java | Checks for correct use of attributes `description` and `name` in annotation `@aQute.bnd.annotation.metatype.Meta`. |
+[JavaMetaAnnotationsCheck](check/java_meta_annotations_check.md#javametaannotationscheck) | .java | Checks for correct use of attributes `description`, `name`, and `type` in annotation `@aQute.bnd.annotation.metatype.Meta`, including requiring `type = Meta.Type.Password` on secret-bearing fields. |
 JavaMissingOverrideCheck | .java | Finds missing @Override annotations. |
 JavaMissingXMLPublicIdsCheck | .java | Finds missing public IDs for check XML files. |
 JavaModifiedServiceMethodCheck | .java | Finds missing empty lines before `removedService` or `addingService` calls. |

--- a/modules/util/source-formatter/src/main/resources/documentation/check/java_meta_annotations_check.md
+++ b/modules/util/source-formatter/src/main/resources/documentation/check/java_meta_annotations_check.md
@@ -11,6 +11,13 @@ A `@Meta.AD` in a configuration that generates UI also requires an explicit
 `name`. Without one, bnd derives the name from the method name, which is not a
 language key, so the configuration fails localization at runtime.
 
+A `String` attribute in a `@Meta.OCD` configuration whose name implies a secret
+(for example a password, an API key, a private key, a client or app secret, or
+an access token) must set `type = Meta.Type.Password`. Without it the value
+renders as a plain text input, exposing the secret on screen. Public
+identifiers such as `accessKey`, `consumerKey`, or a `publicKey` are not secrets
+and are left as plain text.
+
 ### Example
 
 ```java

--- a/modules/util/source-formatter/src/main/resources/documentation/java_source_processor_checks.md
+++ b/modules/util/source-formatter/src/main/resources/documentation/java_source_processor_checks.md
@@ -128,7 +128,7 @@ JavaLogClassNameCheck | [Bug Prevention](bug_prevention_checks.md#bug-prevention
 [JavaLogLevelCheck](check/java_log_level_check.md#javaloglevelcheck) | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | Checks that the correct log messages are printed. |
 JavaLongLinesCheck | [Styling](styling_checks.md#styling-checks) | Finds lines that are longer than the specified maximum line length. |
 JavaMapBuilderGenericsCheck | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | Finds missing or unnecessary generics on `*MapBuilder.put` calls. |
-[JavaMetaAnnotationsCheck](check/java_meta_annotations_check.md#javametaannotationscheck) | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | Checks for correct use of attributes `description` and `name` in annotation `@aQute.bnd.annotation.metatype.Meta`. |
+[JavaMetaAnnotationsCheck](check/java_meta_annotations_check.md#javametaannotationscheck) | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | Checks for correct use of attributes `description`, `name`, and `type` in annotation `@aQute.bnd.annotation.metatype.Meta`, including requiring `type = Meta.Type.Password` on secret-bearing fields. |
 JavaMissingOverrideCheck | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | Finds missing @Override annotations. |
 JavaMissingXMLPublicIdsCheck | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | Finds missing public IDs for check XML files. |
 JavaModifiedServiceMethodCheck | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | Finds missing empty lines before `removedService` or `addingService` calls. |

--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -631,7 +631,7 @@
 		</check>
 		<check name="JavaMetaAnnotationsCheck">
 			<category name="Bug Prevention" />
-			<description name="Checks for correct use of attributes `description` and `name` in annotation `@aQute.bnd.annotation.metatype.Meta`." />
+			<description name="Checks for correct use of attributes `description`, `name`, and `type` in annotation `@aQute.bnd.annotation.metatype.Meta`, including requiring `type = Meta.Type.Password` on secret-bearing fields." />
 			<property name="checkConfigurationName" value="false" />
 		</check>
 		<check name="JavaModifiedServiceMethodCheck">

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/JavaSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/JavaSourceProcessorTest.java
@@ -594,6 +594,22 @@ public class JavaSourceProcessorTest extends BaseSourceProcessorTestCase {
 	}
 
 	@Test
+	public void testMetaAnnotationMissingPasswordType() throws Exception {
+		test(
+			SourceProcessorTestParameters.create(
+				"MetaAnnotationMissingPasswordType.testjava"
+			).addExpectedMessage(
+				"Use \"type = Meta.Type.Password\" in \"@Meta.AD\" for " +
+					"\"apiKey\", which appears to hold a secret",
+				24
+			).addExpectedMessage(
+				"Use \"type = Meta.Type.Password\" in \"@Meta.AD\" for " +
+					"\"clientSecret\", which appears to hold a secret",
+				26
+			));
+	}
+
+	@Test
 	public void testMethodEquals() throws Exception {
 		test(
 			SourceProcessorTestParameters.create(

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/MetaAnnotationMissingPasswordType.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/MetaAnnotationMissingPasswordType.testjava
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies;
+
+import aQute.bnd.annotation.metatype.Meta;
+
+/**
+ * @author Christopher Kian
+ */
+@Meta.OCD(
+	id = "com.liferay.source.formatter.dependencies.MetaAnnotationMissingPasswordType",
+	localization = "content/Language",
+	name = "accessibility-menu-configuration-name"
+)
+public interface MetaAnnotationMissingPasswordType {
+
+	@Meta.AD(name = "access-key", required = false)
+	public String accessKey();
+
+	@Meta.AD(name = "api-key", required = false)
+	public String apiKey();
+
+	public String clientSecret();
+
+	@Meta.AD(name = "consumer-key", required = false)
+	public String consumerKey();
+
+	@Meta.AD(name = "secret-key", required = false, type = Meta.Type.Password)
+	public String secretKey();
+
+}


### PR DESCRIPTION
Part of the LPD-88411 credential-hardening effort (LPD-88886). The earlier PRs masked every credential-bearing configuration field with `type = Meta.Type.Password`; this PR prevents regressions by teaching the source formatter to enforce it.

## What it does

`JavaMetaAnnotationsCheck` now flags a `String` attribute in a `@Meta.OCD` configuration whose name implies a credential (password, API key, private key, client/app secret, access token, etc.) but which does not set `type = Meta.Type.Password`. This covers both a reverted attribute and a newly introduced credential field. Fields with no `@Meta.AD` at all are handled too (a bare `@Meta.AD(type = Meta.Type.Password)` is the fix).

The keyword list is deliberately conservative and pairs with an exclusion list for metadata names (`algorithm`, `keyword`, `providerid`, `type`, `url`, ...). Public identifiers that are not secrets — `accessKey`, `consumerKey`, `publicKey`, `accountSID`, template/selector `*Key` names — are not flagged. Validated across all 487 `@Meta.OCD` configurations: the check fires only on genuine credential fields, zero false positives. Adds `testMetaAnnotationMissingPasswordType` and updates the check documentation.

## About the `ci:test:sf` failure

The failing `sf` run is **not** caused by this change. Because this PR modifies the source-formatter module itself, CI builds the formatter from this branch and runs it repo-wide. The reported issues are pre-existing formatting drift in unrelated files, flagged by other checks:

- `.../headless-cmp-test/.../ContentCoverageResourceTest.java` — `Checkstyle:MissingEmptyLineCheck`
- `.../commerce-product-test/.../CommerceProductStatusUpgradeProcessTest.java` — `AutoBatchPreparedStatementUtil` formatting

These are caught by the freshly-built formatter but not by the currently-released version (`1.0.1603`); the count tracked the base branch advancing, not this change. The new check itself produces zero messages against the base tree (every real secret field is already masked; the only keyword matches are deprecated Solr configs under `modules/apps/archived/`, which the check excludes). None of the reported messages are the `Use "type = Meta.Type.Password"` message this check emits.

Tested at `617793e0541922ab4f2ab0a8c218091f47ce65e4`: `formatSource` clean and `testMetaAnnotationMissingPasswordType` passes.
