### PR TITLE
LPD-99507 Add an SF check for creating reserved system groups as guest

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/SystemGroupGuestUserCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/SystemGroupGuestUserCheck.java
@@ -1,0 +1,64 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.checkstyle.check;
+
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class SystemGroupGuestUserCheck extends BaseCheck {
+
+	@Override
+	public int[] getDefaultTokens() {
+		return new int[] {TokenTypes.METHOD_CALL};
+	}
+
+	@Override
+	protected void doVisitToken(DetailAST detailAST) {
+		if (!Objects.equals(getMethodName(detailAST), "addGroup")) {
+			return;
+		}
+
+		String systemGroupConstantName = null;
+		boolean guestUser = false;
+
+		for (DetailAST parameterExprDetailAST :
+				getParameterExprDetailASTs(detailAST)) {
+
+			List<String> names = getNames(parameterExprDetailAST, true);
+
+			if (names.contains("getGuestUserId")) {
+				guestUser = true;
+			}
+
+			if (!names.contains("GroupConstants")) {
+				continue;
+			}
+
+			for (String name : _SYSTEM_GROUP_CONSTANT_NAMES) {
+				if (names.contains(name)) {
+					systemGroupConstantName = name;
+				}
+			}
+		}
+
+		if ((systemGroupConstantName != null) && !guestUser) {
+			log(detailAST, _MSG_USE_GUEST_USER, systemGroupConstantName);
+		}
+	}
+
+	private static final String _MSG_USE_GUEST_USER = "system.group.guest.user";
+
+	private static final String[] _SYSTEM_GROUP_CONSTANT_NAMES = {
+		"CALENDAR", "CMS", "CONTROL_PANEL", "FORMS", "USER_PERSONAL_SITE"
+	};
+
+}

--- a/modules/util/source-formatter/src/main/resources/checkstyle.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle.xml
@@ -910,6 +910,11 @@
 			<message key="system.event.unneeded.1" value="@SystemEvent on method &quot;{0}&quot; is not needed, because the first parameter is not &quot;{1}&quot;" />
 			<message key="system.event.unneeded.2" value="@SystemEvent on method &quot;{0}&quot; is not needed, because &quot;{1}&quot; does not implement &quot;ClassedModel&quot;" />
 		</module>
+		<module name="com.liferay.source.formatter.checkstyle.check.SystemGroupGuestUserCheck">
+			<property name="category" value="Bug Prevention" />
+			<property name="description" value="Checks that reserved system groups are created with the guest user in tests, so no owner membership dangles after cleanup." />
+			<message key="system.group.guest.user" value="Create the reserved system group &quot;{0}&quot; with the guest user to avoid a dangling membership after cleanup; for the CMS group use &quot;GroupTestUtil.getOrAddCMSGroup&quot;" />
+		</module>
 		<module name="com.liferay.source.formatter.checkstyle.check.TernaryOperatorCheck">
 			<property name="category" value="Styling" />
 			<property name="description" value="Finds use of ternary operator in `java` files (use if statement instead)." />

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/JavaSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/JavaSourceProcessorTest.java
@@ -1039,6 +1039,16 @@ public class JavaSourceProcessorTest extends BaseSourceProcessorTestCase {
 	}
 
 	@Test
+	public void testSystemGroupGuestUser() throws Exception {
+		test(
+			"SystemGroupGuestUser.testjava",
+			StringBundler.concat(
+				"Create the reserved system group \"CMS\" with the guest user ",
+				"to avoid a dangling membership after cleanup; for the CMS ",
+				"group use \"GroupTestUtil.getOrAddCMSGroup\""));
+	}
+
+	@Test
 	public void testTextBlock() throws Exception {
 		test(
 			SourceProcessorTestParameters.create(

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/SystemGroupGuestUser.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/SystemGroupGuestUser.testjava
@@ -1,0 +1,23 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies;
+
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+
+/**
+ * @author Shuyang Zhou
+ */
+public class SystemGroupGuestUser {
+
+	public void test() throws Exception {
+		GroupTestUtil.addGroup(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(), 0,
+			GroupConstants.CMS);
+	}
+
+}


### PR DESCRIPTION
[LPD-99507](https://liferay.atlassian.net/browse/LPD-99507)

## What Is Being Added

`SystemGroupGuestUserCheck`, a Checkstyle-based Source Formatter check that flags any `addGroup(...)` call passing a reserved system group constant (a `GroupConstants.SYSTEM_GROUPS` key such as `CMS`) without the guest user.

## Why

Creating a reserved system group in a test with the shared admin as the creator makes `GroupLocalServiceImpl.addGroup` add the admin to `Users_Groups` as the site owner. Because the group is a system group, DataGuard cannot delete it through the service and falls back to a raw session delete that leaves the membership dangling, breaking later tests in `UserAccount.getSiteBriefs` with `NoSuchGroupException`. The check prevents that anti-pattern from returning and points to `GroupTestUtil.getOrAddCMSGroup` for the CMS group.

## Testing

`JavaSourceProcessorTest.testSystemGroupGuestUser` exercises the check against a fixture, and `format-source` runs clean across the current codebase, which is already free of the pattern, so the check is enabled.

## Related

This check enforces the fix in https://github.com/brianchandotcom/liferay-portal/pull/179194 (LPD-99506), which adds `GroupTestUtil.getOrAddCMSGroup` and migrates every caller. The check's message references that method, so this PR should merge with or after it.
